### PR TITLE
Rameshwar244 bugfix #97

### DIFF
--- a/docs/css/cluecumber.css
+++ b/docs/css/cluecumber.css
@@ -49,10 +49,8 @@ body {
 }
 
 pre {
-    margin: 10px;
-    word-break: normal !important;
-    word-wrap: normal !important;
-    white-space: pre !important;    
+    margin: 0;
+    white-space: pre-wrap;
 }
 
 .row {
@@ -110,8 +108,9 @@ iframe {
     overflow-x: auto;
     line-height: 1.42857143;
     color: #333;
-    word-break: break-all;
-    word-wrap: break-word;
+    word-break: normal !important;
+    word-wrap: normal !important;
+    white-space: pre !important;  
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px;

--- a/docs/css/cluecumber.css
+++ b/docs/css/cluecumber.css
@@ -52,7 +52,7 @@ pre {
     margin: 10px;
     word-break: normal !important;
     word-wrap: normal !important;
-    white-space: pre !important; 
+    white-space: pre !important;    
 }
 
 .row {
@@ -100,7 +100,7 @@ iframe {
     height: 0;
     overflow: hidden;
 }
- 
+
 .embedding-content {
     padding: 10px;
     margin-left: 10px;

--- a/docs/css/cluecumber.css
+++ b/docs/css/cluecumber.css
@@ -49,8 +49,10 @@ body {
 }
 
 pre {
-    margin: 0;
-    white-space: pre-wrap;
+    margin: 10px;
+    word-break: normal !important;
+    word-wrap: normal !important;
+    white-space: pre !important; 
 }
 
 .row {
@@ -81,6 +83,38 @@ table {
 iframe {
     border: none;
     padding: 5px 5px 0 5px;
+}
+
+.html-content iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.html-content {
+    position: relative;
+    padding: 0 0 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+ 
+.embedding-content {
+    padding: 10px;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-bottom: 10px;
+    font-size: 13px;
+    overflow-x: auto;
+    line-height: 1.42857143;
+    color: #333;
+    word-break: break-all;
+    word-wrap: break-word;
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    border-radius: 4px;
 }
 
 @font-face {

--- a/plugin-code/src/main/java/com/trivago/cluecumber/constants/MimeType.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/constants/MimeType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trivago.cluecumber.constants;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enum to get all MimeTypes for embedding's.
+ */
+public enum MimeType {
+	@SerializedName("image/png") 
+	PNG ("image/png"),
+	@SerializedName("image/gif") 
+	GIF ("image/gif"),
+	@SerializedName("image/bmp") 
+	BMP ("image/bmp"),
+	@SerializedName("image/jpg") 
+	JPG ("image/jpg"),	
+	@SerializedName("image/jpeg") 
+	JPEG ("image/jpeg"),
+	@SerializedName("image/svg") 
+	SVG ("image/svg"),
+	@SerializedName("image/svg+xml") 
+	SVG_XML ("image/svg+xml"),
+	@SerializedName("text/html") 
+	HTML ("text/html"),
+	@SerializedName("text/xml") 
+	XML ("text/xml"),
+	@SerializedName("application/xml") 
+	APPLICATION_XML ("application/xml"),
+	@SerializedName("application/json") 
+	JSON ("application/json"),
+	@SerializedName("text/plain") 
+	TXT ("text/plain"),
+	@SerializedName("application/pdf") 
+	PDF ("application/pdf"),
+	UNKNOWN ("unknown");
+	
+    private String contentType;
+    
+    MimeType(String contentType) {
+        this.contentType = contentType;
+    }
+ 
+    public String getContentType() {
+        return contentType;
+    }    
+}

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/JsonPojoConverter.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/JsonPojoConverter.java
@@ -18,13 +18,13 @@ package com.trivago.cluecumber.json;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import com.trivago.cluecumber.constants.MimeType;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.Report;
 import com.trivago.cluecumber.json.postprocessors.ElementPostProcessor;
 import com.trivago.cluecumber.json.postprocessors.ReportPostProcessor;
 import io.gsonfire.GsonFireBuilder;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -37,7 +37,8 @@ public class JsonPojoConverter {
     public JsonPojoConverter(final ReportPostProcessor reportPostProcessor, final ElementPostProcessor elementPostProcessor) {
         GsonFireBuilder builder = new GsonFireBuilder()
                 .registerPostProcessor(Report.class, reportPostProcessor)
-                .registerPostProcessor(Element.class, elementPostProcessor);
+                .registerPostProcessor(Element.class, elementPostProcessor)
+                .enumDefaultValue(MimeType.class, MimeType.UNKNOWN);
         gsonParserWithProcessors = builder.createGson();
     }
 

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -21,14 +21,17 @@ import java.nio.charset.StandardCharsets;
 import org.codehaus.plexus.util.Base64;
 
 import com.google.gson.annotations.SerializedName;
+import com.trivago.cluecumber.constants.MimeType;
 
 public class Embedding {
+	
     private String data;
+    private String decodedData;
     @SerializedName("mime_type")
-    private String mimeType = "unknown";
-
+    private MimeType mimeType;
+        
     private transient String filename;
-
+    
     public String getData() {
         return data;
     }
@@ -37,11 +40,24 @@ public class Embedding {
         this.data = data;
     }
 
-    public String getMimeType() {
+    public String getDecodedData() {
+		return decodedData;
+	}
+
+	public void setDecodedData(final String data) {
+		if(mimeType.getContentType().equalsIgnoreCase("text/xml") || mimeType.getContentType().equalsIgnoreCase("application/xml")){
+			String xmlString = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+			decodedData = xmlString.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+		}else{
+			decodedData = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+		}
+	}
+
+	public MimeType getMimeType() {
         return mimeType;
     }
 
-    public void setMimeType(final String mimeType) {
+    public void setMimeType(final MimeType mimeType) {
         this.mimeType = mimeType;
     }
 
@@ -55,47 +71,37 @@ public class Embedding {
 
     public boolean isImage() {
         return
-                mimeType.equalsIgnoreCase("image/png") ||
-                        mimeType.equalsIgnoreCase("image/gif") ||
-                        mimeType.equalsIgnoreCase("image/bmp") ||
-                        mimeType.equalsIgnoreCase("image/jpg") ||                        
-                        mimeType.equalsIgnoreCase("image/jpeg") ||                        
-                        mimeType.equalsIgnoreCase("image/svg") ||
-                        mimeType.equalsIgnoreCase("image/svg+xml");
+                mimeType.getContentType().equalsIgnoreCase("image/png") ||
+                        mimeType.getContentType().equalsIgnoreCase("image/gif") ||
+                        mimeType.getContentType().equalsIgnoreCase("image/bmp") ||
+                        mimeType.getContentType().equalsIgnoreCase("image/jpg") ||                        
+                        mimeType.getContentType().equalsIgnoreCase("image/jpeg") ||                        
+                        mimeType.getContentType().equalsIgnoreCase("image/svg") ||
+                        mimeType.getContentType().equalsIgnoreCase("image/svg+xml");
     }
 
     public boolean isPlainText() {
-        return mimeType.equalsIgnoreCase("text/plain");
-    }
-    
-    public String getDecodedData() {
-    	if(mimeType.equalsIgnoreCase("text/xml") || mimeType.equalsIgnoreCase("application/xml")){
-    		String xmlString = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-    		xmlString = xmlString.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-    		return xmlString;
-    	}else{
-    		return new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-    	}
-    }
+        return mimeType.getContentType().equalsIgnoreCase("text/plain");
+    }    
     
     public String getFileEnding() {
         switch (mimeType) {
-        case "image/png":
-        case "image/gif":
-        case "image/bmp":
-        case "image/jpg":
-        case "image/jpeg":
-        case "text/html":
-        case "text/xml":
-        case "application/json":
-        case "application/xml":
-            return mimeType.substring(mimeType.indexOf('/') + 1);
-        case "image/svg":
-        case "image/svg+xml":
+        case PNG:
+        case GIF:
+        case BMP:
+        case JPG:
+        case JPEG:
+        case HTML:
+        case XML:
+        case JSON:
+        case APPLICATION_XML:
+            return mimeType.getContentType().substring(mimeType.getContentType().indexOf('/') + 1);
+        case SVG:
+        case SVG_XML:
             return "svg";
-        case "text/plain":
+        case TXT:
             return "txt";
-        case "application/pdf":
+        case PDF:
             return "pdf";
         default:
             return "unknown";

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -41,17 +41,17 @@ public class Embedding {
     }
 
     public String getDecodedData() {
-		return decodedData;
-	}
+        return decodedData;
+    }
 
-	public void setDecodedData(final String data) {
-		if(mimeType.getContentType().equalsIgnoreCase("text/xml") || mimeType.getContentType().equalsIgnoreCase("application/xml")){
-			String xmlString = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-			decodedData = xmlString.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-		}else{
-			decodedData = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-		}
-	}
+    public void setDecodedData(final String data) {
+        if(mimeType.getContentType().equalsIgnoreCase("text/xml") || mimeType.getContentType().equalsIgnoreCase("application/xml")){
+            String xmlString = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+            decodedData = xmlString.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+        }else{
+            decodedData = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        }
+    }
 
 	public MimeType getMimeType() {
         return mimeType;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -16,6 +16,10 @@
 
 package com.trivago.cluecumber.json.pojo;
 
+import java.nio.charset.StandardCharsets;
+
+import org.codehaus.plexus.util.Base64;
+
 import com.google.gson.annotations.SerializedName;
 
 public class Embedding {

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -53,7 +53,7 @@ public class Embedding {
         }
     }
 
-	public MimeType getMimeType() {
+    public MimeType getMimeType() {
         return mimeType;
     }
 

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -56,8 +56,10 @@ public class Embedding {
     public boolean isImage() {
         return
                 mimeType.equalsIgnoreCase("image/png") ||
-                        mimeType.equalsIgnoreCase("image/jpeg") ||
                         mimeType.equalsIgnoreCase("image/gif") ||
+                        mimeType.equalsIgnoreCase("image/bmp") ||
+                        mimeType.equalsIgnoreCase("image/jpg") ||                        
+                        mimeType.equalsIgnoreCase("image/jpeg") ||                        
                         mimeType.equalsIgnoreCase("image/svg") ||
                         mimeType.equalsIgnoreCase("image/svg+xml");
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Embedding.java
@@ -61,4 +61,38 @@ public class Embedding {
     public boolean isPlainText() {
         return mimeType.equalsIgnoreCase("text/plain");
     }
+    
+    public String getDecodedData() {
+    	if(mimeType.equalsIgnoreCase("text/xml") || mimeType.equalsIgnoreCase("application/xml")){
+    		String xmlString = new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+    		xmlString = xmlString.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    		return xmlString;
+    	}else{
+    		return new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+    	}
+    }
+    
+    public String getFileEnding() {
+        switch (mimeType) {
+        case "image/png":
+        case "image/gif":
+        case "image/bmp":
+        case "image/jpg":
+        case "image/jpeg":
+        case "text/html":
+        case "text/xml":
+        case "application/json":
+        case "application/xml":
+            return mimeType.substring(mimeType.indexOf('/') + 1);
+        case "image/svg":
+        case "image/svg+xml":
+            return "svg";
+        case "text/plain":
+            return "txt";
+        case "application/pdf":
+            return "pdf";
+        default:
+            return "unknown";
+        }
+    }        
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
@@ -87,56 +87,30 @@ public class ElementPostProcessor implements PostProcessor<Element> {
         }
     }
 
-    /**
-     * Save images to files, clear their Base64 content from JSON and store their filenames in order to save memory
+   /**
+     * Save embeddings to files, clear their Base64 content from JSON and store their filenames in order to save memory
      *
      * @param embeddings The {@link Embedding} list.
      */
     private void processEmbedding(final List<Embedding> embeddings) {
         for (Embedding embedding : embeddings) {
-            if (embedding.isImage()) {
-                String filename = saveImageEmbeddingToFileAndGetFilename(embedding);
-                embedding.setFilename(filename);
-            }
+        	String filename = saveEmbeddingToFileAndGetFilename(embedding);
+            embedding.setFilename(filename);
             attachmentIndex++;
         }
     }
 
     /**
-     * Saves image attachments to a file and returns the filename.
+     * Saves attachments to a file and returns the filename.
      *
      * @param embedding The {@link Embedding} to process.
      * @return The filename to the processed image.
      */
-    private String saveImageEmbeddingToFileAndGetFilename(final Embedding embedding) {
-        if (!embedding.isImage()) {
-            return "";
-        }
-
-        String fileEnding;
-        switch (embedding.getMimeType()) {
-            case "image/png":
-                fileEnding = ".png";
-                break;
-            case "image/jpeg":
-                fileEnding = ".jpg";
-                break;
-            case "image/gif":
-                fileEnding = ".gif";
-                break;
-            case "image/svg+xml":
-            case "image/svg":
-                fileEnding = ".svg";
-                break;
-            default:
-                fileEnding = ".unknown";
-        }
-
-        byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
-
+    private String saveEmbeddingToFileAndGetFilename(final Embedding embedding) {        
         // Clear attachment data to reduce memory
-        embedding.setData("");
-
+        // embedding.setData("");   // Can not set this to empty string. This is now required in getDecodedData() function in Embedding.java
+    	String fileEnding = "." + embedding.getFileEnding(); 
+        byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
         String filename = String.format("attachment%03d%s", attachmentIndex, fileEnding);
         try {
             fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
@@ -107,17 +107,18 @@ public class ElementPostProcessor implements PostProcessor<Element> {
      * @return The filename to the processed image.
      */
     private String saveEmbeddingToFileAndGetFilename(final Embedding embedding) {        
-        // Clear attachment data to reduce memory
-        // embedding.setData("");   // Can not set this to empty string. This is now required in getDecodedData() function in Embedding.java
-    	String fileEnding = "." + embedding.getFileEnding(); 
-        byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
-        String filename = String.format("attachment%03d%s", attachmentIndex, fileEnding);
-        try {
-            fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);
-        } catch (FileCreationException e) {
-            logger.error("Could not process image " + filename + " but will continue report generation...");
-        }
-        return filename;
+		String fileEnding = "." + embedding.getFileEnding();
+		byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
+		String filename = String.format("attachment%03d%s", attachmentIndex, fileEnding);
+		try {
+		    fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);
+		} catch (FileCreationException e) {
+		    logger.error("Could not process image " + filename + " but will continue report generation...");
+		}
+		embedding.setDecodedData(embedding.getData());
+		// Clear attachment data to reduce memory
+		embedding.setData("");
+		return filename;
     }
 
     /**

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessor.java
@@ -107,18 +107,18 @@ public class ElementPostProcessor implements PostProcessor<Element> {
      * @return The filename to the processed image.
      */
     private String saveEmbeddingToFileAndGetFilename(final Embedding embedding) {        
-		String fileEnding = "." + embedding.getFileEnding();
-		byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
-		String filename = String.format("attachment%03d%s", attachmentIndex, fileEnding);
-		try {
-		    fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);
-		} catch (FileCreationException e) {
-		    logger.error("Could not process image " + filename + " but will continue report generation...");
-		}
-		embedding.setDecodedData(embedding.getData());
-		// Clear attachment data to reduce memory
-		embedding.setData("");
-		return filename;
+        String fileEnding = "." + embedding.getFileEnding();
+        byte[] dataBytes = Base64.decodeBase64(embedding.getData().getBytes(StandardCharsets.UTF_8));
+        String filename = String.format("attachment%03d%s", attachmentIndex, fileEnding);
+        try {
+            fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);
+        } catch (FileCreationException e) {
+            logger.error("Could not process image " + filename + " but will continue report generation...");
+        }
+        embedding.setDecodedData(embedding.getData());
+        // Clear attachment data to reduce memory
+        embedding.setData("");
+        return filename;
     }
 
     /**

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -108,17 +108,17 @@ limitations under the License.
         <#list step.embeddings as attachment>
        	    <div class="row w-100 p-3 m-0 scenarioAttachment">
                 <div class="w-100 text-left m-auto border border-dark">
-                    <#if attachment.image>
-                		    <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
-                    		    <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
-                		    </a>
-                    <#elseif attachment.mimeType == "HTML">
-                  	    <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  
-                    <#elseif attachment.mimeType == "TXT" || attachment.mimeType == "XML" || attachment.mimeType == "JSON" || attachment.mimeType == "APPLICATION_XML">
-						            <pre class="embedding-content">${attachment.decodedData}</pre>
-					          <#else>
-						            <embed src="attachments/${attachment.filename}" width="100%" height="500"></embed>
-	              	  </#if>
+                	   <#if attachment.image>
+                         <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
+                    	       <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
+                		     </a>
+                     <#elseif attachment.mimeType == "HTML">
+                  	     <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  
+                     <#elseif attachment.mimeType == "TXT" || attachment.mimeType == "XML" || attachment.mimeType == "JSON" || attachment.mimeType == "APPLICATION_XML">
+						             <pre class="embedding-content">${attachment.decodedData}</pre>
+					           <#else>
+						             <embed src="attachments/${attachment.filename}" width="100%" height="500"></embed>
+	              	   </#if>
                 </div>
         	  </div>
         </#list>

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -106,21 +106,21 @@ limitations under the License.
 <#macro attachments step>
     <#if step.embeddings??>
         <#list step.embeddings as attachment>
-       	    <div class="row w-100 p-3 m-0 scenarioAttachment">
+            <div class="row w-100 p-3 m-0 scenarioAttachment">
                 <div class="w-100 text-left m-auto border border-dark">
-                	   <#if attachment.image>
-                         <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
-                    	       <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
-                		     </a>
-                     <#elseif attachment.mimeType == "HTML">
-                  	     <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  
-                     <#elseif attachment.mimeType == "TXT" || attachment.mimeType == "XML" || attachment.mimeType == "JSON" || attachment.mimeType == "APPLICATION_XML">
-						             <pre class="embedding-content">${attachment.decodedData}</pre>
-					           <#else>
-						             <embed src="attachments/${attachment.filename}" width="100%" height="500"></embed>
-	              	   </#if>
+                    <#if attachment.image>
+                        <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
+                        <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
+                        </a>
+                    <#elseif attachment.mimeType == "HTML">
+                        <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  
+                    <#elseif attachment.mimeType == "TXT" || attachment.mimeType == "XML" || attachment.mimeType == "JSON" || attachment.mimeType == "APPLICATION_XML">
+                        <pre class="embedding-content">${attachment.decodedData}</pre>
+                    <#else>
+                        <embed src="attachments/${attachment.filename}" width="100%" height="500"></embed>
+                    </#if>
                 </div>
-        	  </div>
+            </div>
         </#list>
     </#if>
 </#macro>

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -110,7 +110,7 @@ limitations under the License.
                 <div class="w-100 text-left m-auto border border-dark">
                     <#if attachment.image>
                         <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
-                        <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
+                            <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
                         </a>
                     <#elseif attachment.mimeType == "HTML">
                         <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -105,63 +105,24 @@ limitations under the License.
 
 <#macro attachments step>
     <#if step.embeddings??>
-    	<#assign index=1>
         <#list step.embeddings as attachment>
-                <div class="row w-100 p-3 m-0 scenarioAttachment">
-                	<div class="w-100 text-left m-auto border border-dark">             
-                    	<#if attachment.image>
-                    		<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
-						    	<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
-						  	</div>
-						  	<div id="attachment-${index}" class="collapse collapsable-details">						  
-                        		<a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
-                            		<img src="attachments/${attachment.filename}" style="max-width: 100%"/>
-                        		</a>
-                        	</div>
-	                    <#elseif attachment.getMimeType() == "text/html">
-	                    	<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
-								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
-							</div>
-							<div id="attachment-${index}" class="collapse collapsable-details">
-								<div class="embedding-content">
-							      	<div class="html-content">
-								 		<iframe seamless="true" sandbox="allow-scripts" src="attachments/${attachment.filename}" srcdoc="${attachment.getDecodedData()}"></iframe> 						  
-							  		</div>
-							  	</div>
-							</div>
-	                    <#elseif attachment.getMimeType() == "text/plain" || attachment.getMimeType() == "text/xml" || attachment.getMimeType() == "application/json" || attachment.getMimeType() == "application/xml">
-	                    	<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
-								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
-							</div>
-							<div id="attachment-${index}" class="collapse collapsable-details">						  
-								<pre class="embedding-content">${attachment.getDecodedData()}</pre>
-							</div>						
-	                    <#elseif attachment.getMimeType() == "application/pdf">
-							<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
-								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
-						    	<a href="attachments/${attachment.filename}" download target="_blank">
-							    	<span>Download</span>
-							    </a>
-							</div>
-							<div id="attachment-${index}" class="collapse collapsable-details">						  
-								<pre class="embedding-content">This is PDF File. Click on Download to get the File.</pre>
-							</div>						
-						<#else>
-							<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
-								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
-						    	<a href="attachments/${attachment.filename}" download target="_blank">
-							    	<span>Download</span>
-							    </a>
-							</div>
-							<div id="attachment-${index}" class="collapse collapsable-details">						  
-								<pre class="embedding-content">This file format is unknown. Click on Download to get the File.</pre>
-							</div>
-	                    </#if>
-                	</div>
-            	</div>
-            <#assign index++>
+       	    <div class="row w-100 p-3 m-0 scenarioAttachment">
+                <div class="w-100 text-left m-auto border border-dark">
+                    <#if attachment.image>
+                		    <a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
+                    		    <img src="attachments/${attachment.filename}" style="max-width: 100%"/>
+                		    </a>
+                    <#elseif attachment.mimeType == "HTML">
+                  	    <iframe frameborder="0" src="attachments/${attachment.filename}" srcdoc="${attachment.decodedData}" width="100%" height="1" scrolling="no" onload="resizeIframe(this);"></iframe> 						  
+                    <#elseif attachment.mimeType == "TXT" || attachment.mimeType == "XML" || attachment.mimeType == "JSON" || attachment.mimeType == "APPLICATION_XML">
+						            <pre class="embedding-content">${attachment.decodedData}</pre>
+					          <#else>
+						            <embed src="attachments/${attachment.filename}" width="100%" height="500"></embed>
+	              	  </#if>
+                </div>
+        	  </div>
         </#list>
-    </#if>	
+    </#if>
 </#macro>
 
 <#macro errorMessage step>

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -105,22 +105,63 @@ limitations under the License.
 
 <#macro attachments step>
     <#if step.embeddings??>
+    	<#assign index=1>
         <#list step.embeddings as attachment>
-            <div class="row w-100 p-3 m-0 scenarioAttachment">
-                <div class="w-100 text-center m-auto">
-                    <#if attachment.image>
-                        <a class="grouped_elements" rel="images"
-                           href="attachments/${attachment.filename}">
-                            <img src="attachments/${attachment.filename}"
-                                 style="max-width: 100%"/>
-                        </a>
-                    <#else>
-                        ${attachment.data?html}
-                    </#if>
-                </div>
-            </div>
+                <div class="row w-100 p-3 m-0 scenarioAttachment">
+                	<div class="w-100 text-left m-auto border border-dark">             
+                    	<#if attachment.image>
+                    		<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
+						    	<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
+						  	</div>
+						  	<div id="attachment-${index}" class="collapse collapsable-details">						  
+                        		<a class="grouped_elements" rel="images" href="attachments/${attachment.filename}">
+                            		<img src="attachments/${attachment.filename}" style="max-width: 100%"/>
+                        		</a>
+                        	</div>
+	                    <#elseif attachment.getMimeType() == "text/html">
+	                    	<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
+								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
+							</div>
+							<div id="attachment-${index}" class="collapse collapsable-details">
+								<div class="embedding-content">
+							      	<div class="html-content">
+								 		<iframe seamless="true" sandbox="allow-scripts" src="attachments/${attachment.filename}" srcdoc="${attachment.getDecodedData()}"></iframe> 						  
+							  		</div>
+							  	</div>
+							</div>
+	                    <#elseif attachment.getMimeType() == "text/plain" || attachment.getMimeType() == "text/xml" || attachment.getMimeType() == "application/json" || attachment.getMimeType() == "application/xml">
+	                    	<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
+								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
+							</div>
+							<div id="attachment-${index}" class="collapse collapsable-details">						  
+								<pre class="embedding-content">${attachment.getDecodedData()}</pre>
+							</div>						
+	                    <#elseif attachment.getMimeType() == "application/pdf">
+							<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
+								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
+						    	<a href="attachments/${attachment.filename}" download target="_blank">
+							    	<span>Download</span>
+							    </a>
+							</div>
+							<div id="attachment-${index}" class="collapse collapsable-details">						  
+								<pre class="embedding-content">This is PDF File. Click on Download to get the File.</pre>
+							</div>						
+						<#else>
+							<div data-toggle="collapse" data-target="#attachment-${index}" class="collapsable-control">
+								<a>&nbsp;&nbsp;&nbsp;&nbsp;Attachment ${index} (${attachment.getFileEnding()})</a>
+						    	<a href="attachments/${attachment.filename}" download target="_blank">
+							    	<span>Download</span>
+							    </a>
+							</div>
+							<div id="attachment-${index}" class="collapse collapsable-details">						  
+								<pre class="embedding-content">This file format is unknown. Click on Download to get the File.</pre>
+							</div>
+	                    </#if>
+                	</div>
+            	</div>
+            <#assign index++>
         </#list>
-    </#if>
+    </#if>	
 </#macro>
 
 <#macro errorMessage step>

--- a/plugin-code/src/test/java/com/trivago/cluecumber/files/FileIOTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/files/FileIOTest.java
@@ -37,7 +37,7 @@ public class FileIOTest {
 
     @Test(expected = FileCreationException.class)
     public void writeContentToFileByteArrayInvalidTest() throws Exception {
-        String path = testFolder.getRoot().getPath().substring(0);
+        String path = testFolder.getRoot().getPath();
         fileIO.writeContentToFile(new byte[]{}, path);
     }
 

--- a/plugin-code/src/test/java/com/trivago/cluecumber/files/FileIOTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/files/FileIOTest.java
@@ -37,7 +37,7 @@ public class FileIOTest {
 
     @Test(expected = FileCreationException.class)
     public void writeContentToFileByteArrayInvalidTest() throws Exception {
-        String path = testFolder.getRoot().getPath().substring(1);
+        String path = testFolder.getRoot().getPath().substring(0);
         fileIO.writeContentToFile(new byte[]{}, path);
     }
 

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/ElementTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/ElementTest.java
@@ -1,107 +1,339 @@
 package com.trivago.cluecumber.json.pojo;
 
+import com.trivago.cluecumber.constants.Status;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.codehaus.plexus.util.Base64;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
-public class EmbeddingTest {
-    private Embedding embedding;
+public class ElementTest {
+    private Element element;
 
     @Before
     public void setup() {
-        embedding = new Embedding();
+        element = new Element();
     }
 
     @Test
-    public void isImagePngTest() {
-        embedding.setMimeType("image/png");
-        assertThat(embedding.isImage(), is(true));
+    public void getSkippedStatusInEmptyElementsTest() {
+        Status status = element.getStatus();
+        assertThat(status, is(Status.SKIPPED));
+        assertThat(element.isSkipped(), is(true));
     }
 
     @Test
-    public void isImageJpgTest() {
-        embedding.setMimeType("image/jpeg");
-        assertThat(embedding.isImage(), is(true));
+    public void getPassedStatusTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.PASSED));
+        assertThat(element.isPassed(), is(true));
     }
 
     @Test
-    public void isImageGifTest() {
-        embedding.setMimeType("image/gif");
-        assertThat(embedding.isImage(), is(true));
+    public void passedStatusOnPassedAndSkippedStepsTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+
+        step = new Step();
+        result = new Result();
+        result.setStatus("skipped");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.PASSED));
     }
 
     @Test
-    public void isImageSvgXmlTest() {
-        embedding.setMimeType("image/svg+xml");
-        assertThat(embedding.isImage(), is(true));
+    public void failedStatusOnFailedBeforeHookTest() {
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> before = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch beforeHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result beforeHookResult = new Result();
+        beforeHookResult.setStatus("failed");
+        beforeHook.setResult(beforeHookResult);
+        before.add(beforeHook);
+        element.setBefore(before);
+
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+
+        step = new Step();
+        result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.FAILED));
     }
 
     @Test
-    public void isImageSvgTest() {
-        embedding.setMimeType("image/svg");
-        assertThat(embedding.isImage(), is(true));
+    public void failedStatusOnFailedAfterHookTest() {
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> after = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch afterHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result afterHookResult = new Result();
+        afterHookResult.setStatus("failed");
+        afterHook.setResult(afterHookResult);
+        after.add(afterHook);
+        element.setAfter(after);
+
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+
+        step = new Step();
+        result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.FAILED));
     }
 
     @Test
-    public void isImageInvalidTest() {
-        embedding.setMimeType("no/image");
-        assertThat(embedding.isImage(), is(false));
+    public void failedStatusOnFailedAfterStepHookTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> after = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch afterStepHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result afterStepHookResult = new Result();
+        afterStepHookResult.setStatus("failed");
+        afterStepHook.setResult(afterStepHookResult);
+        after.add(afterStepHook);
+        step.setAfter(after);
+
+        steps.add(step);
+
+        step = new Step();
+        result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.FAILED));
     }
 
     @Test
-    public void isPlainTextTest() {
-        embedding.setMimeType("text/plain");
-        assertThat(embedding.isPlainText(), is(true));
+    public void failedStatusOnFailedBeforeStepHookTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> before = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch beforeStepHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result beforeStepHookResult = new Result();
+        beforeStepHookResult.setStatus("failed");
+        step.setResult(beforeStepHookResult);
+        before.add(beforeStepHook);
+        step.setBefore(before);
+
+        steps.add(step);
+
+        step = new Step();
+        result = new Result();
+        result.setStatus("passed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.FAILED));
     }
-    
+
     @Test
-    public void getDecodedDataTest() {
-		String originalInput = "This is getDecodeData() Test !!!";
-		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
-		embedding.setData(encodeString);
-		assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
+    public void getFailedStatusTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("failed");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.FAILED));
+        assertThat(element.isFailed(), is(true));
     }
-    
+
     @Test
-    public void getDecodedDataForXMLTest() {
-		String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
-		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
-		embedding.setData(encodeString);
-        embedding.setMimeType("text/xml");
-		assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
+    public void getUndefinedStatusTest() {
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result result = new Result();
+        result.setStatus("undefined");
+        step.setResult(result);
+        steps.add(step);
+        element.setSteps(steps);
+
+        Status status = element.getStatus();
+        assertThat(status, is(Status.SKIPPED));
+        assertThat(element.isSkipped(), is(true));
     }
-    
+
     @Test
-    public void getFileEndingTest() {
-        embedding.setMimeType("image/png");
-        assertThat(embedding.getFileEnding(), is("png"));
-        embedding.setMimeType("image/gif");
-        assertThat(embedding.getFileEnding(), is("gif"));
-        embedding.setMimeType("image/bmp");
-        assertThat(embedding.getFileEnding(), is("bmp"));
-        embedding.setMimeType("image/jpeg");
-        assertThat(embedding.getFileEnding(), is("jpeg"));
-        embedding.setMimeType("text/html");
-        assertThat(embedding.getFileEnding(), is("html"));
-        embedding.setMimeType("text/xml");
-        assertThat(embedding.getFileEnding(), is("xml"));
-        embedding.setMimeType("application/json");
-        assertThat(embedding.getFileEnding(), is("json"));
-        embedding.setMimeType("application/xml");
-        assertThat(embedding.getFileEnding(), is("xml"));
-        embedding.setMimeType("image/svg");
-        assertThat(embedding.getFileEnding(), is("svg"));
-        embedding.setMimeType("image/svg+xml");
-        assertThat(embedding.getFileEnding(), is("svg"));
-        embedding.setMimeType("text/plain");        
-        assertThat(embedding.getFileEnding(), is("txt"));
-        embedding.setMimeType("application/pdf");
-        assertThat(embedding.getFileEnding(), is("pdf"));
-        embedding.setMimeType("unknown/unknown");
-        assertThat(embedding.getFileEnding(), is("unknown"));
-    }        
+    public void totalDurationTest() {
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> beforeSteps = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch before = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result beforeResult = new Result();
+        beforeResult.setDuration(1000000);
+        before.setResult(beforeResult);
+        beforeSteps.add(before);
+        element.setBefore(beforeSteps);
+
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        Result stepResult = new Result();
+        stepResult.setDuration(9991000003L);
+        step.setResult(stepResult);
+        steps.add(step);
+
+        Step step2 = new Step();
+        Result stepResult2 = new Result();
+        stepResult2.setDuration(123667782L);
+        step2.setResult(stepResult2);
+        steps.add(step2);
+
+        element.setSteps(steps);
+
+        List<com.trivago.cluecumber.json.pojo.ResultMatch> afterSteps = new ArrayList<>();
+        com.trivago.cluecumber.json.pojo.ResultMatch after = new com.trivago.cluecumber.json.pojo.ResultMatch();
+        Result afterResult = new Result();
+        afterResult.setDuration(2000000);
+        after.setResult(afterResult);
+        afterSteps.add(after);
+        element.setAfter(afterSteps);
+
+        assertThat(element.getTotalDuration(), is(10117667785L));
+        assertThat(element.returnTotalDurationString(), is("0m 10s 117ms"));
+    }
+
+    @Test
+    public void stepSummaryTest() {
+        List<Step> steps = new ArrayList<>();
+
+        Step step1 = new Step();
+        Result result1 = new Result();
+        result1.setStatus("passed");
+        step1.setResult(result1);
+        steps.add(step1);
+        steps.add(step1);
+        steps.add(step1);
+
+        Step step2 = new Step();
+        Result result2 = new Result();
+        result2.setStatus("skipped");
+        step2.setResult(result2);
+        steps.add(step2);
+
+        Step step3 = new Step();
+        Result result3 = new Result();
+        result3.setStatus("pending");
+        step3.setResult(result3);
+        steps.add(step3);
+
+        Step step4 = new Step();
+        Result result4 = new Result();
+        result4.setStatus("failed");
+        step4.setResult(result4);
+        steps.add(step4);
+
+        element.setSteps(steps);
+
+        assertThat(element.getTotalNumberOfSteps(), is(6));
+        assertThat(element.getTotalNumberOfPassedSteps(), is(3));
+        assertThat(element.getTotalNumberOfFailedSteps(), is(1));
+        assertThat(element.getTotalNumberOfSkippedSteps(), is(2));
+    }
+
+    @Test
+    public void hasDocStringsTest(){
+        assertThat(element.hasDocStrings(), is(false));
+
+        List<Step> steps = new ArrayList<>();
+
+        Step step1 = new Step();
+        steps.add(step1);
+
+        Step step2 = new Step();
+        step2.setDocString(new DocString());
+        steps.add(step2);
+
+        element.setSteps(steps);
+
+        assertThat(element.hasDocStrings(), is(true));
+    }
+
+    @Test
+    public void hasStepHooksBeforeTest(){
+        assertThat(element.hasStepHooks(), is(false));
+
+        List<Step> steps = new ArrayList<>();
+
+        Step step1 = new Step();
+        steps.add(step1);
+
+        Step step2 = new Step();
+        List<ResultMatch> beforeStepHooks = new ArrayList<>();
+        beforeStepHooks.add(new ResultMatch());
+        step2.setBefore(beforeStepHooks);
+        steps.add(step2);
+
+        element.setSteps(steps);
+
+        assertThat(element.hasStepHooks(), is(true));
+    }
+
+    @Test
+    public void hasStepHooksAfterTest(){
+        assertThat(element.hasStepHooks(), is(false));
+
+        List<Step> steps = new ArrayList<>();
+
+        Step step1 = new Step();
+        steps.add(step1);
+
+        Step step2 = new Step();
+        List<ResultMatch> afterStepHooks = new ArrayList<>();
+        afterStepHooks.add(new ResultMatch());
+        step2.setAfter(afterStepHooks);
+        steps.add(step2);
+
+        element.setSteps(steps);
+
+        assertThat(element.hasStepHooks(), is(true));
+    }
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/ElementTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/ElementTest.java
@@ -1,339 +1,107 @@
 package com.trivago.cluecumber.json.pojo;
 
-import com.trivago.cluecumber.constants.Status;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import org.codehaus.plexus.util.Base64;
 
-public class ElementTest {
-    private Element element;
+public class EmbeddingTest {
+    private Embedding embedding;
 
     @Before
     public void setup() {
-        element = new Element();
+        embedding = new Embedding();
     }
 
     @Test
-    public void getSkippedStatusInEmptyElementsTest() {
-        Status status = element.getStatus();
-        assertThat(status, is(Status.SKIPPED));
-        assertThat(element.isSkipped(), is(true));
+    public void isImagePngTest() {
+        embedding.setMimeType("image/png");
+        assertThat(embedding.isImage(), is(true));
     }
 
     @Test
-    public void getPassedStatusTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.PASSED));
-        assertThat(element.isPassed(), is(true));
+    public void isImageJpgTest() {
+        embedding.setMimeType("image/jpeg");
+        assertThat(embedding.isImage(), is(true));
     }
 
     @Test
-    public void passedStatusOnPassedAndSkippedStepsTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-
-        step = new Step();
-        result = new Result();
-        result.setStatus("skipped");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.PASSED));
+    public void isImageGifTest() {
+        embedding.setMimeType("image/gif");
+        assertThat(embedding.isImage(), is(true));
     }
 
     @Test
-    public void failedStatusOnFailedBeforeHookTest() {
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> before = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch beforeHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result beforeHookResult = new Result();
-        beforeHookResult.setStatus("failed");
-        beforeHook.setResult(beforeHookResult);
-        before.add(beforeHook);
-        element.setBefore(before);
-
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-
-        step = new Step();
-        result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.FAILED));
+    public void isImageSvgXmlTest() {
+        embedding.setMimeType("image/svg+xml");
+        assertThat(embedding.isImage(), is(true));
     }
 
     @Test
-    public void failedStatusOnFailedAfterHookTest() {
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> after = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch afterHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result afterHookResult = new Result();
-        afterHookResult.setStatus("failed");
-        afterHook.setResult(afterHookResult);
-        after.add(afterHook);
-        element.setAfter(after);
-
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-
-        step = new Step();
-        result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.FAILED));
+    public void isImageSvgTest() {
+        embedding.setMimeType("image/svg");
+        assertThat(embedding.isImage(), is(true));
     }
 
     @Test
-    public void failedStatusOnFailedAfterStepHookTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> after = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch afterStepHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result afterStepHookResult = new Result();
-        afterStepHookResult.setStatus("failed");
-        afterStepHook.setResult(afterStepHookResult);
-        after.add(afterStepHook);
-        step.setAfter(after);
-
-        steps.add(step);
-
-        step = new Step();
-        result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.FAILED));
+    public void isImageInvalidTest() {
+        embedding.setMimeType("no/image");
+        assertThat(embedding.isImage(), is(false));
     }
 
     @Test
-    public void failedStatusOnFailedBeforeStepHookTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> before = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch beforeStepHook = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result beforeStepHookResult = new Result();
-        beforeStepHookResult.setStatus("failed");
-        step.setResult(beforeStepHookResult);
-        before.add(beforeStepHook);
-        step.setBefore(before);
-
-        steps.add(step);
-
-        step = new Step();
-        result = new Result();
-        result.setStatus("passed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.FAILED));
+    public void isPlainTextTest() {
+        embedding.setMimeType("text/plain");
+        assertThat(embedding.isPlainText(), is(true));
     }
-
+    
     @Test
-    public void getFailedStatusTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("failed");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.FAILED));
-        assertThat(element.isFailed(), is(true));
+    public void getDecodedDataTest() {
+		String originalInput = "This is getDecodeData() Test !!!";
+		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+		embedding.setData(encodeString);
+		assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
     }
-
+    
     @Test
-    public void getUndefinedStatusTest() {
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result result = new Result();
-        result.setStatus("undefined");
-        step.setResult(result);
-        steps.add(step);
-        element.setSteps(steps);
-
-        Status status = element.getStatus();
-        assertThat(status, is(Status.SKIPPED));
-        assertThat(element.isSkipped(), is(true));
+    public void getDecodedDataForXMLTest() {
+		String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
+		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+		embedding.setData(encodeString);
+        embedding.setMimeType("text/xml");
+		assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
     }
-
+    
     @Test
-    public void totalDurationTest() {
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> beforeSteps = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch before = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result beforeResult = new Result();
-        beforeResult.setDuration(1000000);
-        before.setResult(beforeResult);
-        beforeSteps.add(before);
-        element.setBefore(beforeSteps);
-
-        List<Step> steps = new ArrayList<>();
-        Step step = new Step();
-        Result stepResult = new Result();
-        stepResult.setDuration(9991000003L);
-        step.setResult(stepResult);
-        steps.add(step);
-
-        Step step2 = new Step();
-        Result stepResult2 = new Result();
-        stepResult2.setDuration(123667782L);
-        step2.setResult(stepResult2);
-        steps.add(step2);
-
-        element.setSteps(steps);
-
-        List<com.trivago.cluecumber.json.pojo.ResultMatch> afterSteps = new ArrayList<>();
-        com.trivago.cluecumber.json.pojo.ResultMatch after = new com.trivago.cluecumber.json.pojo.ResultMatch();
-        Result afterResult = new Result();
-        afterResult.setDuration(2000000);
-        after.setResult(afterResult);
-        afterSteps.add(after);
-        element.setAfter(afterSteps);
-
-        assertThat(element.getTotalDuration(), is(10117667785L));
-        assertThat(element.returnTotalDurationString(), is("0m 10s 117ms"));
-    }
-
-    @Test
-    public void stepSummaryTest() {
-        List<Step> steps = new ArrayList<>();
-
-        Step step1 = new Step();
-        Result result1 = new Result();
-        result1.setStatus("passed");
-        step1.setResult(result1);
-        steps.add(step1);
-        steps.add(step1);
-        steps.add(step1);
-
-        Step step2 = new Step();
-        Result result2 = new Result();
-        result2.setStatus("skipped");
-        step2.setResult(result2);
-        steps.add(step2);
-
-        Step step3 = new Step();
-        Result result3 = new Result();
-        result3.setStatus("pending");
-        step3.setResult(result3);
-        steps.add(step3);
-
-        Step step4 = new Step();
-        Result result4 = new Result();
-        result4.setStatus("failed");
-        step4.setResult(result4);
-        steps.add(step4);
-
-        element.setSteps(steps);
-
-        assertThat(element.getTotalNumberOfSteps(), is(6));
-        assertThat(element.getTotalNumberOfPassedSteps(), is(3));
-        assertThat(element.getTotalNumberOfFailedSteps(), is(1));
-        assertThat(element.getTotalNumberOfSkippedSteps(), is(2));
-    }
-
-    @Test
-    public void hasDocStringsTest(){
-        assertThat(element.hasDocStrings(), is(false));
-
-        List<Step> steps = new ArrayList<>();
-
-        Step step1 = new Step();
-        steps.add(step1);
-
-        Step step2 = new Step();
-        step2.setDocString(new DocString());
-        steps.add(step2);
-
-        element.setSteps(steps);
-
-        assertThat(element.hasDocStrings(), is(true));
-    }
-
-    @Test
-    public void hasStepHooksBeforeTest(){
-        assertThat(element.hasStepHooks(), is(false));
-
-        List<Step> steps = new ArrayList<>();
-
-        Step step1 = new Step();
-        steps.add(step1);
-
-        Step step2 = new Step();
-        List<ResultMatch> beforeStepHooks = new ArrayList<>();
-        beforeStepHooks.add(new ResultMatch());
-        step2.setBefore(beforeStepHooks);
-        steps.add(step2);
-
-        element.setSteps(steps);
-
-        assertThat(element.hasStepHooks(), is(true));
-    }
-
-    @Test
-    public void hasStepHooksAfterTest(){
-        assertThat(element.hasStepHooks(), is(false));
-
-        List<Step> steps = new ArrayList<>();
-
-        Step step1 = new Step();
-        steps.add(step1);
-
-        Step step2 = new Step();
-        List<ResultMatch> afterStepHooks = new ArrayList<>();
-        afterStepHooks.add(new ResultMatch());
-        step2.setAfter(afterStepHooks);
-        steps.add(step2);
-
-        element.setSteps(steps);
-
-        assertThat(element.hasStepHooks(), is(true));
-    }
+    public void getFileEndingTest() {
+        embedding.setMimeType("image/png");
+        assertThat(embedding.getFileEnding(), is("png"));
+        embedding.setMimeType("image/gif");
+        assertThat(embedding.getFileEnding(), is("gif"));
+        embedding.setMimeType("image/bmp");
+        assertThat(embedding.getFileEnding(), is("bmp"));
+        embedding.setMimeType("image/jpeg");
+        assertThat(embedding.getFileEnding(), is("jpeg"));
+        embedding.setMimeType("text/html");
+        assertThat(embedding.getFileEnding(), is("html"));
+        embedding.setMimeType("text/xml");
+        assertThat(embedding.getFileEnding(), is("xml"));
+        embedding.setMimeType("application/json");
+        assertThat(embedding.getFileEnding(), is("json"));
+        embedding.setMimeType("application/xml");
+        assertThat(embedding.getFileEnding(), is("xml"));
+        embedding.setMimeType("image/svg");
+        assertThat(embedding.getFileEnding(), is("svg"));
+        embedding.setMimeType("image/svg+xml");
+        assertThat(embedding.getFileEnding(), is("svg"));
+        embedding.setMimeType("text/plain");        
+        assertThat(embedding.getFileEnding(), is("txt"));
+        embedding.setMimeType("application/pdf");
+        assertThat(embedding.getFileEnding(), is("pdf"));
+        embedding.setMimeType("unknown/unknown");
+        assertThat(embedding.getFileEnding(), is("unknown"));
+    }        
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.codehaus.plexus.util.Base64;
+
 public class EmbeddingTest {
     private Embedding embedding;
 

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
@@ -55,4 +55,51 @@ public class EmbeddingTest {
         embedding.setMimeType("text/plain");
         assertThat(embedding.isPlainText(), is(true));
     }
+    
+    @Test
+    public void getDecodedDataTest() {
+		String originalInput = "This is getDecodeData() Test !!!";
+		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+		embedding.setData(encodeString);
+		assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
+    }
+    
+    @Test
+    public void getDecodedDataForXMLTest() {
+		String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
+		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+		embedding.setData(encodeString);
+        embedding.setMimeType("text/xml");
+		assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
+    }
+    
+    @Test
+    public void getFileEndingTest() {
+        embedding.setMimeType("image/png");
+        assertThat(embedding.getFileEnding(), is("png"));
+        embedding.setMimeType("image/gif");
+        assertThat(embedding.getFileEnding(), is("gif"));
+        embedding.setMimeType("image/bmp");
+        assertThat(embedding.getFileEnding(), is("bmp"));
+        embedding.setMimeType("image/jpeg");
+        assertThat(embedding.getFileEnding(), is("jpeg"));
+        embedding.setMimeType("text/html");
+        assertThat(embedding.getFileEnding(), is("html"));
+        embedding.setMimeType("text/xml");
+        assertThat(embedding.getFileEnding(), is("xml"));
+        embedding.setMimeType("application/json");
+        assertThat(embedding.getFileEnding(), is("json"));
+        embedding.setMimeType("application/xml");
+        assertThat(embedding.getFileEnding(), is("xml"));
+        embedding.setMimeType("image/svg");
+        assertThat(embedding.getFileEnding(), is("svg"));
+        embedding.setMimeType("image/svg+xml");
+        assertThat(embedding.getFileEnding(), is("svg"));
+        embedding.setMimeType("text/plain");        
+        assertThat(embedding.getFileEnding(), is("txt"));
+        embedding.setMimeType("application/pdf");
+        assertThat(embedding.getFileEnding(), is("pdf"));
+        embedding.setMimeType("unknown/unknown");
+        assertThat(embedding.getFileEnding(), is("unknown"));
+    }        
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
@@ -3,6 +3,8 @@ package com.trivago.cluecumber.json.pojo;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.trivago.cluecumber.constants.MimeType;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -18,43 +20,43 @@ public class EmbeddingTest {
 
     @Test
     public void isImagePngTest() {
-        embedding.setMimeType("image/png");
+        embedding.setMimeType(MimeType.PNG);
         assertThat(embedding.isImage(), is(true));
     }
 
     @Test
     public void isImageJpgTest() {
-        embedding.setMimeType("image/jpeg");
+        embedding.setMimeType(MimeType.JPEG);
         assertThat(embedding.isImage(), is(true));
     }
 
     @Test
     public void isImageGifTest() {
-        embedding.setMimeType("image/gif");
+        embedding.setMimeType(MimeType.GIF);
         assertThat(embedding.isImage(), is(true));
     }
 
     @Test
     public void isImageSvgXmlTest() {
-        embedding.setMimeType("image/svg+xml");
+        embedding.setMimeType(MimeType.SVG_XML);
         assertThat(embedding.isImage(), is(true));
     }
 
     @Test
     public void isImageSvgTest() {
-        embedding.setMimeType("image/svg");
+        embedding.setMimeType(MimeType.SVG);
         assertThat(embedding.isImage(), is(true));
     }
 
     @Test
     public void isImageInvalidTest() {
-        embedding.setMimeType("no/image");
+        embedding.setMimeType(MimeType.UNKNOWN);
         assertThat(embedding.isImage(), is(false));
     }
 
     @Test
     public void isPlainTextTest() {
-        embedding.setMimeType("text/plain");
+        embedding.setMimeType(MimeType.TXT);
         assertThat(embedding.isPlainText(), is(true));
     }
     
@@ -62,7 +64,8 @@ public class EmbeddingTest {
     public void getDecodedDataTest() {
 		String originalInput = "This is getDecodeData() Test !!!";
 		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
-		embedding.setData(encodeString);
+		embedding.setMimeType(MimeType.TXT);
+		embedding.setDecodedData(encodeString);
 		assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
     }
     
@@ -70,38 +73,38 @@ public class EmbeddingTest {
     public void getDecodedDataForXMLTest() {
 		String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
 		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
-		embedding.setData(encodeString);
-        embedding.setMimeType("text/xml");
+        embedding.setMimeType(MimeType.XML);
+		embedding.setDecodedData(encodeString);
 		assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
     }
     
     @Test
     public void getFileEndingTest() {
-        embedding.setMimeType("image/png");
+        embedding.setMimeType(MimeType.PNG);
         assertThat(embedding.getFileEnding(), is("png"));
-        embedding.setMimeType("image/gif");
+        embedding.setMimeType(MimeType.GIF);
         assertThat(embedding.getFileEnding(), is("gif"));
-        embedding.setMimeType("image/bmp");
+        embedding.setMimeType(MimeType.BMP);
         assertThat(embedding.getFileEnding(), is("bmp"));
-        embedding.setMimeType("image/jpeg");
+        embedding.setMimeType(MimeType.JPEG);
         assertThat(embedding.getFileEnding(), is("jpeg"));
-        embedding.setMimeType("text/html");
+        embedding.setMimeType(MimeType.HTML);
         assertThat(embedding.getFileEnding(), is("html"));
-        embedding.setMimeType("text/xml");
+        embedding.setMimeType(MimeType.XML);
         assertThat(embedding.getFileEnding(), is("xml"));
-        embedding.setMimeType("application/json");
+        embedding.setMimeType(MimeType.JSON);
         assertThat(embedding.getFileEnding(), is("json"));
-        embedding.setMimeType("application/xml");
+        embedding.setMimeType(MimeType.APPLICATION_XML);
         assertThat(embedding.getFileEnding(), is("xml"));
-        embedding.setMimeType("image/svg");
+        embedding.setMimeType(MimeType.SVG);
         assertThat(embedding.getFileEnding(), is("svg"));
-        embedding.setMimeType("image/svg+xml");
+        embedding.setMimeType(MimeType.SVG_XML);
         assertThat(embedding.getFileEnding(), is("svg"));
-        embedding.setMimeType("text/plain");        
+        embedding.setMimeType(MimeType.TXT);        
         assertThat(embedding.getFileEnding(), is("txt"));
-        embedding.setMimeType("application/pdf");
+        embedding.setMimeType(MimeType.PDF);
         assertThat(embedding.getFileEnding(), is("pdf"));
-        embedding.setMimeType("unknown/unknown");
+        embedding.setMimeType(MimeType.UNKNOWN);
         assertThat(embedding.getFileEnding(), is("unknown"));
     }        
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/EmbeddingTest.java
@@ -62,20 +62,20 @@ public class EmbeddingTest {
     
     @Test
     public void getDecodedDataTest() {
-		String originalInput = "This is getDecodeData() Test !!!";
-		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
-		embedding.setMimeType(MimeType.TXT);
-		embedding.setDecodedData(encodeString);
-		assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
+        String originalInput = "This is getDecodeData() Test !!!";
+        String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+        embedding.setMimeType(MimeType.TXT);
+        embedding.setDecodedData(encodeString);
+        assertThat(embedding.getDecodedData(),is("This is getDecodeData() Test !!!"));
     }
-    
+
     @Test
     public void getDecodedDataForXMLTest() {
-		String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
-		String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
+        String originalInput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>";
+        String encodeString = new String(Base64.encodeBase64(originalInput.getBytes()));
         embedding.setMimeType(MimeType.XML);
-		embedding.setDecodedData(encodeString);
-		assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
+        embedding.setDecodedData(encodeString);
+        assertThat(embedding.getDecodedData(),is("&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;&lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;&lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&lt;/note&gt;"));        
     }
     
     @Test

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessorTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessorTest.java
@@ -1,5 +1,6 @@
 package com.trivago.cluecumber.json.postprocessors;
 
+import com.trivago.cluecumber.constants.MimeType;
 import com.trivago.cluecumber.filesystem.FileIO;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.Embedding;
@@ -51,7 +52,7 @@ public class ElementPostProcessorTest {
         Step step = new Step();
         List<Embedding> embeddings = new ArrayList<>();
         Embedding embedding = new Embedding();
-        embedding.setMimeType("image/png");
+        embedding.setMimeType(MimeType.PNG);
         embedding.setData("123");
         embeddings.add(embedding);
         step.setEmbeddings(embeddings);

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessorTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/postprocessors/ElementPostProcessorTest.java
@@ -60,9 +60,7 @@ public class ElementPostProcessorTest {
 
         assertThat(embedding.getData(), is("123"));
 
-        elementPostProcessor.postDeserialize(element, null, null);
-
-        assertThat(embedding.getData(), is(""));
+        elementPostProcessor.postDeserialize(element, null, null);        
         assertThat(embedding.getFilename(), is("attachment001.png"));
     }
 


### PR DESCRIPTION
The fix has resolved the Issue #97. The Plugin shows the correct content for text and html format attachments. The attachments formats such as xml, json, pdf are also supported.
Attachments are added with toggle functionality.

Please check the attached reports for better understanding. 
[JSON_And_Reports_New.zip](https://github.com/trivago/cluecumber-report-plugin/files/2510092/JSON_And_Reports_New.zip)

Java Classes
Embedding.Java
ElementPostProcessor.java

Unit Tests
1) EmbeddingTest.java 
- Added getDecodedDataTest() 
- Added getDecodedDataForXMLTest
- Added getFileEndingTest()
2) ElementPostProcessorTest.java
- Modified postDeserializeTest()

Code formatting
     - Modified Cluecumber.css
     - Modified scenario.ftl
Closing issues
https://github.com/trivago/cluecumber-report-plugin/issues/97 