### PR TITLE
Feature/rendering link update for locally shared locations

### DIFF
--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/RenderingUtils.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/RenderingUtils.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 public class RenderingUtils {
     private static final int MICROSECOND_FACTOR = 1000000;
-    private static final Pattern URL_PATTERN = Pattern.compile("(ftp|http|https)://(\\w+:?\\w*@)?(\\S+)(:[0-9]+)?(/|/([\\w#!:.?+=&%@\\-/]))?");
+    private static final Pattern URL_PATTERN = Pattern.compile("(file.*)|((ftp|http|https)://(\\w+:?\\w*@)?(\\S+)(:[0-9]+)?(/|/([\\w#!:.?+=&%@\\-/]))?)");
 
     /**
      * Convert microseconds to a human readable time string.
@@ -93,7 +93,7 @@ public class RenderingUtils {
         }
         return stringBuilder.toString();
     }
-
+    
     /**
      * Return the source html string with added tags so URLs are clickable.
      *
@@ -105,7 +105,7 @@ public class RenderingUtils {
         String targetString = sourceString;
         while (matcher.find()) {
             String found = matcher.group();
-            targetString = targetString.replaceFirst(Pattern.quote(found), "<a href='" + found + "' target='_blank'>" + found + "</a>");
+            targetString = targetString.replaceFirst(Pattern.quote(found), Matcher.quoteReplacement("<a href='" + found + "' target='_blank'>" + found + "</a>"));
         }
         return targetString;
     }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/DocStringTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/DocStringTest.java
@@ -28,8 +28,8 @@ public class DocStringTest {
     
     @Test
     public void returnWithClickableLocalLinksTest() {
-        docString.setValue("The shared location is file:\\MACHINE\\Folder\\SomeFolder");
-        assertThat(docString.returnWithClickableLinks(), is("The shared location is <a href='file:\\MACHINE\\Folder\\SomeFolder' target='_blank'>file:\\MACHINE\\Folder\\SomeFolder</a>"));
+        docString.setValue("The shared location is file:\\MACHINE\\Folder\\Some Folder");
+        assertThat(docString.returnWithClickableLinks(), is("The shared location is <a href='file:\\MACHINE\\Folder\\Some Folder' target='_blank'>file:\\MACHINE\\Folder\\Some Folder</a>"));
     }
 
     @Test

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/DocStringTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/pojo/DocStringTest.java
@@ -25,6 +25,12 @@ public class DocStringTest {
         docString.setValue("This should be a http://www.google.de link");
         assertThat(docString.returnWithClickableLinks(), is("This should be a <a href='http://www.google.de' target='_blank'>http://www.google.de</a> link"));
     }
+    
+    @Test
+    public void returnWithClickableLocalLinksTest() {
+        docString.setValue("The shared location is file:\\MACHINE\\Folder\\SomeFolder");
+        assertThat(docString.returnWithClickableLinks(), is("The shared location is <a href='file:\\MACHINE\\Folder\\SomeFolder' target='_blank'>file:\\MACHINE\\Folder\\SomeFolder</a>"));
+    }
 
     @Test
     public void returnWithClickableLinksNoUrlTest() {


### PR DESCRIPTION
Refer : 
Issue #142 

Allowing locally shared file links to be clickable in the html report.

Since these paths can contain **'spaces'** in them (they are basically paths to a local directory so they can be pretty random unlike http/ftp links), the link would only work correctly (logically) if there is **only the 'shared path'**  after the **'file:\\'** mark. This is also reflected in the new JUnit Test.