### PR TITLE
1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Back to [Readme](README.md).
 ### Fixed
 
 * Steps that are only skipped should not have a link to a scenario from the minimum/maximum time in `All Steps`
+* Feature name on `Scenario Details` page was incorrectly linked
 
 ### Changed
 
@@ -20,6 +21,8 @@ Back to [Readme](README.md).
 ### Added
 
 * Additional parallel run time on `All Scenarios` and `Scenario Sequence` pages
+* Support of Cucumber 4.3.0's new scenario start timestamps
+* Start time and date is displayed on each scenario in `All Scenarios`, `Scenario Sequence` and `Scenario Detail` pages (Cucumber >= 4.3.0)
 
 ## [1.9.0] - 2019-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Back to [Readme](README.md).
 
+## [1.9.1] - UNRELEASED
+
+### Fixed
+
+* Steps that are only skipped should not have a link to a scenario from the minimum/maximum time in `All Steps`
+
+### Changed
+
+* `Scenario Sequence` is now not based on start time if it exists in the json file
+
+### Added
+
+* Additional parallel run time on `All Scenarios` and `Scenario Sequence` pages
+
 ## [1.9.0] - 2019-04-10
 
 ### Added
@@ -406,6 +420,7 @@ steps with status `pending` or `undefined` (default value is `false`) (#74)
 
 Initial project version on GitHub and Maven Central.
 
+[1.9.1]: https://github.com/trivago/cluecumber-report-plugin/tree/1.9.1
 [1.9.0]: https://github.com/trivago/cluecumber-report-plugin/tree/1.9.0
 [1.8.1]: https://github.com/trivago/cluecumber-report-plugin/tree/1.8.1
 [1.8.0]: https://github.com/trivago/cluecumber-report-plugin/tree/1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Back to [Readme](README.md).
 
-## [1.9.1] - UNRELEASED
+## [1.10.0] - UNRELEASED
 
 ### Fixed
 
 * Steps that are only skipped should not have a link to a scenario from the minimum/maximum time in `All Steps`
 * Feature name on `Scenario Details` page was incorrectly linked
 
-### Changed
-
-* `Scenario Sequence` is now not based on start time if it exists in the json file
-
 ### Added
 
 * Additional parallel run time on `All Scenarios` and `Scenario Sequence` pages
 * Support of Cucumber 4.3.0's new scenario start timestamps
-* Start time and date is displayed on each scenario in `All Scenarios`, `Scenario Sequence` and `Scenario Detail` pages (Cucumber >= 4.3.0)
+* Start time and date, end time and date and duration is displayed on each scenario in `All Scenarios`, `Scenario Sequence` and `Scenario Detail` pages (Cucumber >= 4.3.0)
+
+### Changed
+
+* `Scenario Sequence` is now not based on start time if it exists in the json file
+* Minor design changes
 
 ## [1.9.0] - 2019-04-10
 
@@ -423,7 +424,7 @@ steps with status `pending` or `undefined` (default value is `false`) (#74)
 
 Initial project version on GitHub and Maven Central.
 
-[1.9.1]: https://github.com/trivago/cluecumber-report-plugin/tree/1.9.1
+[1.10.0]: https://github.com/trivago/cluecumber-report-plugin/tree/1.10.0
 [1.9.0]: https://github.com/trivago/cluecumber-report-plugin/tree/1.9.0
 [1.8.1]: https://github.com/trivago/cluecumber-report-plugin/tree/1.8.1
 [1.8.0]: https://github.com/trivago/cluecumber-report-plugin/tree/1.8.0

--- a/example-project/json/scenarios_with_start_timestamp.json
+++ b/example-project/json/scenarios_with_start_timestamp.json
@@ -5,7 +5,7 @@
       {
         "start_timestamp": "2019-04-11T08:00:23.668Z",
         "line": 6,
-        "name": "Display Book Details",
+        "name": "Scenario with timestamp 1",
         "description": "",
         "id": "shopping",
         "type": "scenario",
@@ -52,7 +52,7 @@
       {
         "start_timestamp": "2019-04-11T08:00:15.091Z",
         "line": 10,
-        "name": "Search For Book",
+        "name": "Scenario with timestamp 2",
         "description": "",
         "id": "vendor-shopping-cart;search-for-book",
         "type": "scenario",
@@ -111,7 +111,7 @@
       {
         "start_timestamp": "2019-04-11T08:00:25.829Z",
         "line": 10,
-        "name": "Search For Book",
+        "name": "Scenario with timestamp 3",
         "description": "",
         "id": "vendor-shopping-cart;search-for-book",
         "type": "scenario",

--- a/example-project/json/scenarios_with_start_timestamp.json
+++ b/example-project/json/scenarios_with_start_timestamp.json
@@ -1,0 +1,179 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2019-04-11T08:00:23.668Z",
+        "line": 6,
+        "name": "Display Book Details",
+        "description": "",
+        "id": "shopping",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 467889821,
+              "status": "passed"
+            },
+            "line": 7,
+            "name": "I search for book \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 19
+                }
+              ],
+              "location": "MySteps.I_search(String)"
+            },
+            "keyword": "When "
+          },
+          {
+            "result": {
+              "duration": 1691629452,
+              "status": "passed"
+            },
+            "line": 8,
+            "name": "the results include \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 21
+                }
+              ],
+              "location": "MySteps.search_results_include(String)"
+            },
+            "keyword": "Then "
+          }
+        ]
+      },
+      {
+        "start_timestamp": "2019-04-11T08:00:15.091Z",
+        "line": 10,
+        "name": "Search For Book",
+        "description": "",
+        "id": "vendor-shopping-cart;search-for-book",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 5224289914,
+              "status": "passed"
+            },
+            "line": 11,
+            "name": "I am on a vendor page",
+            "match": {
+              "location": "MySteps.I_visit_vendor()"
+            },
+            "keyword": "Given "
+          },
+          {
+            "result": {
+              "duration": 1084130235,
+              "status": "passed"
+            },
+            "line": 12,
+            "name": "I search for book \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 19
+                }
+              ],
+              "location": "MySteps.I_search(String)"
+            },
+            "keyword": "When "
+          },
+          {
+            "result": {
+              "duration": 2266563900,
+              "status": "passed"
+            },
+            "line": 13,
+            "name": "the results include \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 21
+                }
+              ],
+              "location": "MySteps.search_results_include(String)"
+            },
+            "keyword": "Then "
+          }
+        ]
+      },
+      {
+        "start_timestamp": "2019-04-11T08:00:25.829Z",
+        "line": 10,
+        "name": "Search For Book",
+        "description": "",
+        "id": "vendor-shopping-cart;search-for-book",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "result": {
+              "error_message": "org.openqa.selenium.TimeoutException: Expected condition failed: waiting for title to contain \"Vendor.com: Online Shopping \". Current title: \"Vendor.com: Something\" (tried for 10 second(s) with 500 MILLISECONDS interval)\nBuild info: version: \u00273.5.3\u0027, revision: \u0027a88d25fe6b\u0027, time: \u00272017-08-29T12:42:44.417Z\u0027\nSystem info: host: \u0027Unitys-MacBook-Pro.local\u0027, ip: \u0027fe80:0:0:0:894:f27b:4dac:67bc%en0\u0027, os.name: \u0027Mac OS X\u0027, os.arch: \u0027x86_64\u0027, os.version: \u002710.13.6\u0027, java.version: \u00271.8.0_202\u0027\nDriver info: org.openqa.selenium.firefox.FirefoxDriver\nCapabilities [{moz:profile\u003d/var/folders/gb/gc676v7s5zz1qq1c9mql2jq00000gp/T/rust_mozprofile.j0nIk1SCX7ek, rotatable\u003dfalse, moz:geckodriverVersion\u003d0.24.0, timeouts\u003d{implicit\u003d0, pageLoad\u003d300000, script\u003d30000}, pageLoadStrategy\u003dnormal, unhandledPromptBehavior\u003ddismiss and notify, strictFileInteractability\u003dfalse, moz:headless\u003dfalse, platform\u003dMAC, moz:accessibilityChecks\u003dfalse, moz:useNonSpecCompliantPointerOrigin\u003dfalse, acceptInsecureCerts\u003dfalse, browserVersion\u003d66.0.2, moz:shutdownTimeout\u003d60000, platformVersion\u003d17.7.0, moz:processID\u003d9614, browserName\u003dfirefox, javascriptEnabled\u003dtrue, platformName\u003dMAC, setWindowRect\u003dtrue, moz:webdriverClick\u003dtrue}]\nSession ID: 32553156-6956-9e46-96a2-55b6932ae415\n\tat org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:80)\n\tat org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:232)\n\tat org.graphwalker.MySteps.I_visit_vendor(MySteps.java:28)\n\tat ✽.I am on a vendor page(classpath:org/graphwalker/ShoppingCart.feature:11)\n",
+              "duration": 10368348419,
+              "status": "failed"
+            },
+            "line": 11,
+            "name": "I am on a vendor page",
+            "match": {
+              "location": "MySteps.I_visit_vendor()"
+            },
+            "keyword": "Given "
+          },
+          {
+            "result": {
+              "duration": 13530,
+              "status": "skipped"
+            },
+            "line": 12,
+            "name": "I search for book \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 19
+                }
+              ],
+              "location": "MySteps.I_search(String)"
+            },
+            "keyword": "When "
+          },
+          {
+            "result": {
+              "duration": 4502,
+              "status": "skipped"
+            },
+            "line": 13,
+            "name": "the results include \"Something\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "Something",
+                  "offset": 21
+                }
+              ],
+              "location": "MySteps.search_results_include(String)"
+            },
+            "keyword": "Then "
+          }
+        ]
+      }
+    ],
+    "name": "Vendor Shopping Cart",
+    "description": "  As a bookworm\n  I\u0027d like to be able to search for my favourite book\n  so I can buy them",
+    "id": "vendor-shopping-cart",
+    "keyword": "Feature",
+    "uri": "classpath:org/graphwalker/ShoppingCart.feature",
+    "tags": []
+  }
+]

--- a/example-project/json/scenarios_with_start_timestamp.json
+++ b/example-project/json/scenarios_with_start_timestamp.json
@@ -119,7 +119,7 @@
         "steps": [
           {
             "result": {
-              "error_message": "org.openqa.selenium.TimeoutException: Expected condition failed: waiting for title to contain \"Vendor.com: Online Shopping \". Current title: \"Vendor.com: Something\" (tried for 10 second(s) with 500 MILLISECONDS interval)\nBuild info: version: \u00273.5.3\u0027, revision: \u0027a88d25fe6b\u0027, time: \u00272017-08-29T12:42:44.417Z\u0027\nSystem info: host: \u0027Unitys-MacBook-Pro.local\u0027, ip: \u0027fe80:0:0:0:894:f27b:4dac:67bc%en0\u0027, os.name: \u0027Mac OS X\u0027, os.arch: \u0027x86_64\u0027, os.version: \u002710.13.6\u0027, java.version: \u00271.8.0_202\u0027\nDriver info: org.openqa.selenium.firefox.FirefoxDriver\nCapabilities [{moz:profile\u003d/var/folders/gb/gc676v7s5zz1qq1c9mql2jq00000gp/T/rust_mozprofile.j0nIk1SCX7ek, rotatable\u003dfalse, moz:geckodriverVersion\u003d0.24.0, timeouts\u003d{implicit\u003d0, pageLoad\u003d300000, script\u003d30000}, pageLoadStrategy\u003dnormal, unhandledPromptBehavior\u003ddismiss and notify, strictFileInteractability\u003dfalse, moz:headless\u003dfalse, platform\u003dMAC, moz:accessibilityChecks\u003dfalse, moz:useNonSpecCompliantPointerOrigin\u003dfalse, acceptInsecureCerts\u003dfalse, browserVersion\u003d66.0.2, moz:shutdownTimeout\u003d60000, platformVersion\u003d17.7.0, moz:processID\u003d9614, browserName\u003dfirefox, javascriptEnabled\u003dtrue, platformName\u003dMAC, setWindowRect\u003dtrue, moz:webdriverClick\u003dtrue}]\nSession ID: 32553156-6956-9e46-96a2-55b6932ae415\n\tat org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:80)\n\tat org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:232)\n\tat org.graphwalker.MySteps.I_visit_vendor(MySteps.java:28)\n\tat ✽.I am on a vendor page(classpath:org/graphwalker/ShoppingCart.feature:11)\n",
+              "error_message": "org.openqa.selenium.TimeoutException: Expected condition failed: waiting for title to contain \"Vendor.com: Online Shopping \".",
               "duration": 10368348419,
               "status": "failed"
             },
@@ -170,10 +170,10 @@
       }
     ],
     "name": "Vendor Shopping Cart",
-    "description": "  As a bookworm\n  I\u0027d like to be able to search for my favourite book\n  so I can buy them",
+    "description": "I\u0027d like to be able to search for my favourite book",
     "id": "vendor-shopping-cart",
     "keyword": "Feature",
-    "uri": "classpath:org/graphwalker/ShoppingCart.feature",
+    "uri": "classpath:org/ShoppingCart.feature",
     "tags": []
   }
 ]

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.benjamin-bischoff</groupId>
     <artifactId>cluecumber-test-project</artifactId>
-    <version>1.9.1</version>
+    <version>1.10.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cucumber.report.json.location>${project.basedir}/json</cucumber.report.json.location>
+        <cucumber.report.json.location>${project.basedir}/json3</cucumber.report.json.location>
         <generated.report.location>${project.build.directory}/cluecumber-report</generated.report.location>
     </properties>
 

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cucumber.report.json.location>${project.basedir}/json3</cucumber.report.json.location>
+        <cucumber.report.json.location>${project.basedir}/json</cucumber.report.json.location>
         <generated.report.location>${project.build.directory}/cluecumber-report</generated.report.location>
     </properties>
 

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.benjamin-bischoff</groupId>
     <artifactId>cluecumber-test-project</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/plugin-code/pom.xml
+++ b/plugin-code/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.trivago.rta</groupId>
     <artifactId>cluecumber-report-plugin</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
     <url>https://github.com/trivago/cluecumber-report-plugin</url>
 
     <name>Cluecumber Maven Plugin for Cucumber Reports</name>

--- a/plugin-code/pom.xml
+++ b/plugin-code/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.trivago.rta</groupId>
     <artifactId>cluecumber-report-plugin</artifactId>
-    <version>1.9.1</version>
+    <version>1.10.0</version>
     <url>https://github.com/trivago/cluecumber-report-plugin</url>
 
     <name>Cluecumber Maven Plugin for Cucumber Reports</name>

--- a/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
@@ -22,6 +22,7 @@ import com.trivago.cluecumber.filesystem.FileIO;
 import com.trivago.cluecumber.filesystem.FileSystemManager;
 import com.trivago.cluecumber.json.JsonPojoConverter;
 import com.trivago.cluecumber.json.pojo.Report;
+import com.trivago.cluecumber.json.processors.ElementIndexPreProcessor;
 import com.trivago.cluecumber.logging.CluecumberLogger;
 import com.trivago.cluecumber.properties.PropertyManager;
 import com.trivago.cluecumber.rendering.ReportGenerator;
@@ -47,6 +48,7 @@ public final class CluecumberReportPlugin extends AbstractMojo {
     private final FileSystemManager fileSystemManager;
     private final FileIO fileIO;
     private final JsonPojoConverter jsonPojoConverter;
+    private final ElementIndexPreProcessor elementIndexPreProcessor;
     private final ReportGenerator reportGenerator;
 
     /**
@@ -110,6 +112,7 @@ public final class CluecumberReportPlugin extends AbstractMojo {
             final FileSystemManager fileSystemManager,
             final FileIO fileIO,
             final JsonPojoConverter jsonPojoConverter,
+            final ElementIndexPreProcessor elementIndexPreProcessor,
             final ReportGenerator reportGenerator
     ) {
         this.propertyManager = propertyManager;
@@ -117,6 +120,7 @@ public final class CluecumberReportPlugin extends AbstractMojo {
         this.fileIO = fileIO;
         this.jsonPojoConverter = jsonPojoConverter;
         this.logger = logger;
+        this.elementIndexPreProcessor = elementIndexPreProcessor;
         this.reportGenerator = reportGenerator;
     }
 
@@ -164,7 +168,7 @@ public final class CluecumberReportPlugin extends AbstractMojo {
                 logger.error("Could not parse JSON in file '" + jsonFilePath.toString() + "': " + e.getMessage());
             }
         }
-
+        elementIndexPreProcessor.addScenarioIndices(allScenariosPageCollection.getReports());
         reportGenerator.generateReport(allScenariosPageCollection);
         logger.info(
                 "=> Cluecumber Report: " + propertyManager.getGeneratedHtmlReportDirectory() + "/" +

--- a/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
@@ -149,9 +149,9 @@ public final class CluecumberReportPlugin extends AbstractMojo {
         propertyManager.setCustomCss(customCss);
         propertyManager.validateSettings();
 
-        logger.info("-----------------------------------------------");
+        logger.logSeparator();
         logger.info(String.format(" Cluecumber Report Maven Plugin, version %s", getClass().getPackage().getImplementationVersion()));
-        logger.info("-----------------------------------------------");
+        logger.logSeparator();
         propertyManager.logProperties();
 
         // Create attachment directory here since they are handled during json generation.

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/JsonPojoConverter.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/JsonPojoConverter.java
@@ -22,9 +22,10 @@ import com.trivago.cluecumber.constants.MimeType;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.Report;
-import com.trivago.cluecumber.json.postprocessors.ElementPostProcessor;
-import com.trivago.cluecumber.json.postprocessors.ReportPostProcessor;
+import com.trivago.cluecumber.json.processors.ElementJsonPostProcessor;
+import com.trivago.cluecumber.json.processors.ReportJsonPostProcessor;
 import io.gsonfire.GsonFireBuilder;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -34,10 +35,13 @@ public class JsonPojoConverter {
     private final Gson gsonParserWithProcessors;
 
     @Inject
-    public JsonPojoConverter(final ReportPostProcessor reportPostProcessor, final ElementPostProcessor elementPostProcessor) {
+    public JsonPojoConverter(
+            final ReportJsonPostProcessor reportJsonPostProcessor,
+            final ElementJsonPostProcessor elementJsonPostProcessor
+    ) {
         GsonFireBuilder builder = new GsonFireBuilder()
-                .registerPostProcessor(Report.class, reportPostProcessor)
-                .registerPostProcessor(Element.class, elementPostProcessor)
+                .registerPostProcessor(Report.class, reportJsonPostProcessor)
+                .registerPostProcessor(Element.class, elementJsonPostProcessor)
                 .enumDefaultValue(MimeType.class, MimeType.UNKNOWN);
         gsonParserWithProcessors = builder.createGson();
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Element.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Element.java
@@ -63,12 +63,29 @@ public class Element {
         return RenderingUtils.convertTimestampToZonedDateTime(startTimestamp);
     }
 
+    public ZonedDateTime getEndDateTime() {
+        ZonedDateTime startDateTime = getStartDateTime();
+        if (startDateTime != null) {
+            return getStartDateTime().plusNanos(getTotalDuration());
+        } else {
+            return null;
+        }
+    }
+
     public String getStartDateString() {
         return RenderingUtils.convertZonedDateTimeToDateString(getStartDateTime());
     }
 
     public String getStartTimeString() {
         return RenderingUtils.convertZonedDateTimeToTimeString(getStartDateTime());
+    }
+
+    public String getEndDateString() {
+        return RenderingUtils.convertZonedDateTimeToDateString(getEndDateTime());
+    }
+
+    public String getEndTimeString() {
+        return RenderingUtils.convertZonedDateTimeToTimeString(getEndDateTime());
     }
 
     public List<ResultMatch> getBefore() {

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Element.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/pojo/Element.java
@@ -16,9 +16,11 @@
 
 package com.trivago.cluecumber.json.pojo;
 
+import com.google.gson.annotations.SerializedName;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.rendering.RenderingUtils;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,8 +36,10 @@ public class Element {
     private String keyword = "";
     private List<Step> steps = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
+    @SerializedName("start_timestamp")
+    private String startTimestamp = "";
 
-    private int featureIndex = 0;
+    private transient int featureIndex = 0;
     private transient int scenarioIndex = 0;
     private transient boolean failOnPendingOrUndefined = false;
 
@@ -45,6 +49,26 @@ public class Element {
 
     public void setTags(final List<Tag> tags) {
         this.tags = tags;
+    }
+
+    public String getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(final String startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    public ZonedDateTime getStartDateTime() {
+        return RenderingUtils.convertTimestampToZonedDateTime(startTimestamp);
+    }
+
+    public String getStartDateString() {
+        return RenderingUtils.convertZonedDateTimeToDateString(getStartDateTime());
+    }
+
+    public String getStartTimeString() {
+        return RenderingUtils.convertZonedDateTimeToTimeString(getStartDateTime());
     }
 
     public List<ResultMatch> getBefore() {
@@ -156,10 +180,10 @@ public class Element {
 
         // If all steps have the same status, return this as the scenario status.
         for (Status status : Status.BASIC_STATES) {
-            long count = 0L;
+            int stepsWithCertainStatusCount = 0;
             for (Step step : steps) {
                 if (step.getConsolidatedStatus() == status) {
-                    count++;
+                    stepsWithCertainStatusCount++;
                 }
 
                 // If any step hooks fail, report scenario as failed.
@@ -175,8 +199,7 @@ public class Element {
                 }
             }
 
-            int stepNumber = (int) count;
-            if (totalSteps == stepNumber) {
+            if (totalSteps == stepsWithCertainStatusCount) {
                 if (status == Status.SKIPPED) {
                     if (failOnPendingOrUndefined) {
                         return Status.FAILED;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementIndexPreProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementIndexPreProcessor.java
@@ -1,0 +1,34 @@
+package com.trivago.cluecumber.json.processors;
+
+import com.trivago.cluecumber.json.pojo.Element;
+import com.trivago.cluecumber.json.pojo.Report;
+
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Singleton
+public class ElementIndexPreProcessor {
+
+    public void addScenarioIndices(final List<Report> reports) {
+        List<Element> elements = new ArrayList<>();
+        for (Report report : reports) {
+            elements.addAll(report.getElements());
+        }
+
+        List<Element> sortedElements =
+                elements.stream().
+                        sorted(Comparator.comparing(Element::getStartTimestamp)).
+                        collect(Collectors.toList());
+
+        int scenarioIndex = 0;
+        for (Element element : sortedElements) {
+            if (element.isScenario()) {
+                scenarioIndex++;
+                element.setScenarioIndex(scenarioIndex);
+            }
+        }
+    }
+}

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.trivago.cluecumber.json.postprocessors;
+package com.trivago.cluecumber.json.processors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -35,17 +35,16 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Singleton
-public class ElementPostProcessor implements PostProcessor<Element> {
+public class ElementJsonPostProcessor implements PostProcessor<Element> {
 
     private final PropertyManager propertyManager;
     private final FileIO fileIO;
     private final CluecumberLogger logger;
 
-    private int scenarioIndex = 1;
     private int attachmentIndex = 1;
 
     @Inject
-    public ElementPostProcessor(
+    public ElementJsonPostProcessor(
             final PropertyManager propertyManager,
             final FileIO fileIO,
             final CluecumberLogger logger
@@ -57,7 +56,6 @@ public class ElementPostProcessor implements PostProcessor<Element> {
 
     @Override
     public void postDeserialize(final Element element, final JsonElement jsonElement, final Gson gson) {
-        addScenarioIndex(element);
         element.setFailOnPendingOrUndefined(propertyManager.isFailScenariosOnPendingOrUndefinedSteps());
         processAttachments(element.getSteps(), element.getAfter());
     }
@@ -120,20 +118,6 @@ public class ElementPostProcessor implements PostProcessor<Element> {
         // Clear attachment data to reduce memory
         embedding.setData("");
         return filename;
-    }
-
-    /**
-     * Add index to scenarios (used for link creation to the detail reports).
-     *
-     * @param element The current {@link Element}.
-     */
-    private void addScenarioIndex(final Element element) {
-        // Filter out background scenarios
-        if (!element.isScenario()) {
-            return;
-        }
-        element.setScenarioIndex(scenarioIndex);
-        scenarioIndex++;
     }
 
     @Override

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ReportJsonPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ReportJsonPostProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.trivago.cluecumber.json.postprocessors;
+package com.trivago.cluecumber.json.processors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -31,12 +31,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Singleton
-public class ReportPostProcessor implements PostProcessor<Report> {
+public class ReportJsonPostProcessor implements PostProcessor<Report> {
 
     private final List<String> featureUris;
 
     @Inject
-    public ReportPostProcessor() {
+    public ReportJsonPostProcessor() {
         featureUris = new ArrayList<>();
     }
 

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/RenderingUtils.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/RenderingUtils.java
@@ -19,6 +19,8 @@ package com.trivago.cluecumber.rendering;
 import org.jsoup.Jsoup;
 
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -93,7 +95,7 @@ public class RenderingUtils {
         }
         return stringBuilder.toString();
     }
-    
+
     /**
      * Return the source html string with added tags so URLs are clickable.
      *
@@ -108,5 +110,36 @@ public class RenderingUtils {
             targetString = targetString.replaceFirst(Pattern.quote(found), Matcher.quoteReplacement("<a href='" + found + "' target='_blank'>" + found + "</a>"));
         }
         return targetString;
+    }
+
+    /**
+     * Return a {@link ZonedDateTime} from a timestamp string.
+     *
+     * @param timestampString the timestamp string.
+     * @return the converted {@link ZonedDateTime}.
+     */
+    public static ZonedDateTime convertTimestampToZonedDateTime(final String timestampString) {
+        try {
+            return ZonedDateTime.parse(timestampString);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+
+    public static String convertZonedDateTimeToDateString(final ZonedDateTime startDateTime) {
+        try {
+            return startDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        } catch (Exception ignored) {
+        }
+        return "";
+    }
+
+    public static String convertZonedDateTimeToTimeString(final ZonedDateTime startDateTime) {
+        try {
+            return startDateTime.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+        } catch (Exception ignored) {
+        }
+        return "";
     }
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/pojos/ReportDetails.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/pojos/ReportDetails.java
@@ -30,7 +30,7 @@ public class ReportDetails {
 
     public ReportDetails(final String pageName) {
         this.pageName = pageName;
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date date = new Date();
         this.date = dateFormat.format(date);
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/pojos/pagecollections/AllScenariosPageCollection.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/pojos/pagecollections/AllScenariosPageCollection.java
@@ -134,7 +134,7 @@ public class AllScenariosPageCollection extends PageCollection {
         ZonedDateTime latestEndDateTime = null;
         for (Report report : reports) {
             for (Element element : report.getElements()) {
-                ZonedDateTime currentEndDateTime = element.getStartDateTime().plusNanos(element.getTotalDuration());
+                ZonedDateTime currentEndDateTime = element.getEndDateTime();
                 if (latestEndDateTime == null || currentEndDateTime.isAfter(latestEndDateTime)) {
                     latestEndDateTime = currentEndDateTime;
                 }

--- a/plugin-code/src/main/resources/template/css/cluecumber.css
+++ b/plugin-code/src/main/resources/template/css/cluecumber.css
@@ -206,3 +206,8 @@ div.collapse {
 i {
     color: #135A74;
 }
+
+.customParameters .card-body,
+.customParameters .card-body td {
+    padding: .5rem 1rem;
+}

--- a/plugin-code/src/main/resources/template/macros/scenario.ftl
+++ b/plugin-code/src/main/resources/template/macros/scenario.ftl
@@ -34,13 +34,16 @@ limitations under the License.
 
                     <#switch status>
                         <#case "skipped">
-                            <div class="card-header border-warning bg-warning">Skipped Scenarios <@common.startStatus status="skipped"/></div>
+                            <div class="card-header border-warning bg-warning">Skipped
+                                Scenarios <@common.startStatus status="skipped"/></div>
                             <#break>
                         <#case "failed">
-                            <div class="card-header border-danger bg-danger text-white">Failed Scenarios <@common.startStatus status="failed"/></div>
+                            <div class="card-header border-danger bg-danger text-white">Failed
+                                Scenarios <@common.startStatus status="failed"/></div>
                             <#break>
                         <#case "passed">
-                            <div class="card-header border-success bg-success text-white">Passed Scenarios <@common.startStatus status="passed"/></div>
+                            <div class="card-header border-success bg-success text-white">Passed
+                                Scenarios <@common.startStatus status="passed"/></div>
                             <#break>
                         <#case "all">
                             <div class="card-header border-light bg-info text-white">Scenario Sequence</div>
@@ -56,6 +59,7 @@ limitations under the License.
                                 </#if>
                                 <th class="text-left">Feature</th>
                                 <th class="text-left">Scenario</th>
+                                <th>Started</th>
                                 <th>Duration</th>
                                 <#if allRequested>
                                     <th class="text-left">Status</th>
@@ -83,6 +87,9 @@ limitations under the License.
                                             <td class="text-left">
                                                 <a href="pages/scenario-detail/scenario_${element.scenarioIndex?c}.html"
                                                    style="word-break: break-all">${element.name?html}</a>
+                                            </td>
+                                            <td class="text-center small" data-order="${element.startTimestamp}">
+                                                ${element.startDateString}<br>${element.startTimeString}
                                             </td>
                                             <td class="text-right small"
                                                 data-order="${element.totalDuration}">

--- a/plugin-code/src/main/resources/template/scenario-detail.ftl
+++ b/plugin-code/src/main/resources/template/scenario-detail.ftl
@@ -39,9 +39,12 @@ preheadlineLink="pages/feature-scenarios/feature_${element.featureIndex?c}.html"
                     ${element.totalNumberOfSkippedSteps} <@common.status status="skipped"/>
                 </li>
                 <#if element.startTimestamp?has_content>
-                    <li class="list-group-item">${element.startDateString}<br>${element.startTimeString}</li>
+                    <li class="list-group-item">Started on:<br>${element.startDateString} ${element.startTimeString}</li>
                 </#if>
-                <li class="list-group-item">${element.returnTotalDurationString()}</li>
+                <#if element.startTimestamp?has_content>
+                    <li class="list-group-item">Ended on:<br>${element.endDateString} ${element.endTimeString}</li>
+                </#if>
+                <li class="list-group-item">Test Runtime:<br>${element.returnTotalDurationString()}</li>
                 <li class="list-group-item"><#list element.tags as tag>
                         <a href="pages/tag-scenarios/tag_${tag.getUrlFriendlyName()}.html">${tag.name}</a><#sep>,
                     </#list>

--- a/plugin-code/src/main/resources/template/scenario-detail.ftl
+++ b/plugin-code/src/main/resources/template/scenario-detail.ftl
@@ -25,7 +25,7 @@ links=["feature_summary", "tag_summary", "step_summary", "scenario_sequence", "s
 headline="${element.name?html}"
 subheadline="${element.description?html}"
 preheadline="${element.featureName?html}"
-preheadlineLink="pages/feature-scenarios/feature_${element.scenarioIndex?c}.html">
+preheadlineLink="pages/feature-scenarios/feature_${element.featureIndex?c}.html">
 
     <div class="row">
         <@page.card width="8" title="Scenario Result Chart" subtitle="" classes="">
@@ -33,12 +33,13 @@ preheadlineLink="pages/feature-scenarios/feature_${element.scenarioIndex?c}.html
         </@page.card>
         <@page.card width="4" title="Scenario Information" subtitle="" classes="">
             <ul class="list-group list-group-flush">
-                <li class="list-group-item">${element.totalNumberOfSteps} Step(s)</li>
-                <li class="list-group-item">
+                <li class="list-group-item">${element.totalNumberOfSteps} Step(s)<br>
                     ${element.totalNumberOfPassedSteps} <@common.status status="passed"/>
                     ${element.totalNumberOfFailedSteps} <@common.status status="failed"/>
                     ${element.totalNumberOfSkippedSteps} <@common.status status="skipped"/>
                 </li>
+                <li class="list-group-item">Date: ${element.startDateString}</li>
+                <li class="list-group-item">Time: ${element.startTimeString}</li>
                 <li class="list-group-item">Duration: ${element.returnTotalDurationString()}</li>
                 <li class="list-group-item"><#list element.tags as tag>
                         <a href="pages/tag-scenarios/tag_${tag.getUrlFriendlyName()}.html">${tag.name}</a><#sep>,

--- a/plugin-code/src/main/resources/template/scenario-detail.ftl
+++ b/plugin-code/src/main/resources/template/scenario-detail.ftl
@@ -38,9 +38,10 @@ preheadlineLink="pages/feature-scenarios/feature_${element.featureIndex?c}.html"
                     ${element.totalNumberOfFailedSteps} <@common.status status="failed"/>
                     ${element.totalNumberOfSkippedSteps} <@common.status status="skipped"/>
                 </li>
-                <li class="list-group-item">Date: ${element.startDateString}</li>
-                <li class="list-group-item">Time: ${element.startTimeString}</li>
-                <li class="list-group-item">Duration: ${element.returnTotalDurationString()}</li>
+                <#if element.startTimestamp?has_content>
+                    <li class="list-group-item">${element.startDateString}<br>${element.startTimeString}</li>
+                </#if>
+                <li class="list-group-item">${element.returnTotalDurationString()}</li>
                 <li class="list-group-item"><#list element.tags as tag>
                         <a href="pages/tag-scenarios/tag_${tag.getUrlFriendlyName()}.html">${tag.name}</a><#sep>,
                     </#list>

--- a/plugin-code/src/main/resources/template/scenario-summary.ftl
+++ b/plugin-code/src/main/resources/template/scenario-summary.ftl
@@ -85,7 +85,12 @@ preheadlineLink="">
                     ${totalNumberOfFailedScenarios} <@common.status status="failed"/>
                     ${totalNumberOfSkippedScenarios} <@common.status status="skipped"/>
                 </li>
-                <li class="list-group-item" data-cluecumber-item="total-scenario-duration">Duration: ${totalDurationString}</li>
+                <#if startTimestamp??>
+                    <li class="list-group-item" data-cluecumber-item="scenario-start">
+                        Started: ${startDateString} ${startTimeString}</li>
+                </#if>
+                <li class="list-group-item" data-cluecumber-item="total-scenario-duration">
+                    Duration: ${totalDurationString}</li>
             </ul>
         </@page.card>
     </div>

--- a/plugin-code/src/main/resources/template/scenario-summary.ftl
+++ b/plugin-code/src/main/resources/template/scenario-summary.ftl
@@ -51,7 +51,7 @@ preheadlineLink="">
 
     <#if hasCustomParameters()>
         <div class="row">
-            <@page.card width="12" title="" subtitle="" classes="">
+            <@page.card width="12" title="" subtitle="" classes="customParameters">
                 <table class="table table-fit">
                     <tbody>
                     <#list customParameters as customParameter>
@@ -85,12 +85,18 @@ preheadlineLink="">
                     ${totalNumberOfFailedScenarios} <@common.status status="failed"/>
                     ${totalNumberOfSkippedScenarios} <@common.status status="skipped"/>
                 </li>
-                <#if startTimestamp?has_content>
-                    <li class="list-group-item" data-cluecumber-item="scenario-start">
-                        Started: ${startDateString} ${startTimeString}</li>
+                <#if startDateTimeString?has_content>
+                    <li class="list-group-item" data-cluecumber-item="total-start">
+                        Started on:<br>${startDateTimeString}</li>
                 </#if>
-                <li class="list-group-item" data-cluecumber-item="total-scenario-duration">
-                    ${totalDurationString}</li>
+                <#if endDateTimeString?has_content>
+                    <li class="list-group-item" data-cluecumber-item="total-end">
+                        Ended on:<br>${endDateTimeString}</li>
+                </#if>
+
+                <li class="list-group-item" data-cluecumber-item="total-runtime">
+                    Test Runtime:<br>${totalDurationString}
+                </li>
             </ul>
         </@page.card>
     </div>

--- a/plugin-code/src/main/resources/template/scenario-summary.ftl
+++ b/plugin-code/src/main/resources/template/scenario-summary.ftl
@@ -85,12 +85,12 @@ preheadlineLink="">
                     ${totalNumberOfFailedScenarios} <@common.status status="failed"/>
                     ${totalNumberOfSkippedScenarios} <@common.status status="skipped"/>
                 </li>
-                <#if startTimestamp??>
+                <#if startTimestamp?has_content>
                     <li class="list-group-item" data-cluecumber-item="scenario-start">
                         Started: ${startDateString} ${startTimeString}</li>
                 </#if>
                 <li class="list-group-item" data-cluecumber-item="total-scenario-duration">
-                    Duration: ${totalDurationString}</li>
+                    ${totalDurationString}</li>
             </ul>
         </@page.card>
     </div>

--- a/plugin-code/src/main/resources/template/step-summary.ftl
+++ b/plugin-code/src/main/resources/template/step-summary.ftl
@@ -72,8 +72,16 @@ preheadlineLink="">
                         <td class="text-right">${stepResultCount.passed}</td>
                         <td class="text-right">${stepResultCount.failed}</td>
                         <td class="text-right">${stepResultCount.skipped}</td>
-                        <td class="text-right small"><a href="pages/scenario-detail/scenario_${getMinimumTimeScenarioIndexFromStep(step)}.html">${getMinimumTimeFromStep(step)}</a></td>
-                        <td class="text-right small"><a href="pages/scenario-detail/scenario_${getMaximumTimeScenarioIndexFromStep(step)}.html">${getMaximumTimeFromStep(step)}</a></td>
+                        <td class="text-right small">
+                            <#if (getMinimumTimeScenarioIndexFromStep(step) > -1)>
+                                <a href="pages/scenario-detail/scenario_${getMinimumTimeScenarioIndexFromStep(step)}.html">${getMinimumTimeFromStep(step)}</a>
+                            </#if>
+                        </td>
+                        <td class="text-right small">
+                            <#if (getMaximumTimeScenarioIndexFromStep(step) > -1)>
+                                <a href="pages/scenario-detail/scenario_${getMaximumTimeScenarioIndexFromStep(step)}.html">${getMaximumTimeFromStep(step)}</a>
+                            </#if>
+                        </td>
                         <td class="text-right small">${getAverageTimeFromStep(step)}</td>
                     </tr>
                 </#list>

--- a/plugin-code/src/test/java/com/trivago/cluecumber/CluecumberReportPluginTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/CluecumberReportPluginTest.java
@@ -4,6 +4,7 @@ import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.filesystem.FileIO;
 import com.trivago.cluecumber.filesystem.FileSystemManager;
 import com.trivago.cluecumber.json.JsonPojoConverter;
+import com.trivago.cluecumber.json.processors.ElementIndexPreProcessor;
 import com.trivago.cluecumber.logging.CluecumberLogger;
 import com.trivago.cluecumber.properties.PropertyManager;
 import com.trivago.cluecumber.rendering.ReportGenerator;
@@ -38,13 +39,16 @@ public class CluecumberReportPluginTest {
 
         fileIO = mock(FileIO.class);
         jsonPojoConverter = mock(JsonPojoConverter.class);
+        ElementIndexPreProcessor elementIndexPostProcessor = mock(ElementIndexPreProcessor.class);
         ReportGenerator reportGenerator = mock(ReportGenerator.class);
+
         cluecumberReportPlugin = new CluecumberReportPlugin(
                 cluecumberLogger,
                 propertyManager,
                 fileSystemManager,
                 fileIO,
                 jsonPojoConverter,
+                elementIndexPostProcessor,
                 reportGenerator
         );
     }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/JsonPojoConverterTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/JsonPojoConverterTest.java
@@ -4,14 +4,14 @@ import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.Report;
-import com.trivago.cluecumber.json.postprocessors.ElementPostProcessor;
-import com.trivago.cluecumber.json.postprocessors.ReportPostProcessor;
+import com.trivago.cluecumber.json.processors.ElementJsonPostProcessor;
+import com.trivago.cluecumber.json.processors.ReportJsonPostProcessor;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 
 public class JsonPojoConverterTest {
@@ -19,9 +19,12 @@ public class JsonPojoConverterTest {
 
     @Before
     public void setup() {
-        ElementPostProcessor elementPostProcessor = mock(ElementPostProcessor.class);
-        ReportPostProcessor reportPostProcessor = mock(ReportPostProcessor.class);
-        pojoConverter = new JsonPojoConverter(reportPostProcessor, elementPostProcessor);
+        ElementJsonPostProcessor elementJsonPostProcessor = mock(ElementJsonPostProcessor.class);
+        ReportJsonPostProcessor reportJsonPostProcessor = mock(ReportJsonPostProcessor.class);
+        pojoConverter = new JsonPojoConverter(
+                reportJsonPostProcessor,
+                elementJsonPostProcessor
+        );
     }
 
     @Test

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessorTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessorTest.java
@@ -1,4 +1,4 @@
-package com.trivago.cluecumber.json.postprocessors;
+package com.trivago.cluecumber.json.processors;
 
 import com.trivago.cluecumber.constants.MimeType;
 import com.trivago.cluecumber.filesystem.FileIO;
@@ -18,32 +18,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 
-public class ElementPostProcessorTest {
-    private ElementPostProcessor elementPostProcessor;
+public class ElementJsonPostProcessorTest {
+    private ElementJsonPostProcessor elementJsonPostProcessor;
 
     @Before
     public void setup() {
         PropertyManager propertyManager = mock(PropertyManager.class);
         FileIO fileIO = mock(FileIO.class);
         CluecumberLogger logger = new CluecumberLogger();
-        elementPostProcessor = new ElementPostProcessor(propertyManager, fileIO, logger);
+        elementJsonPostProcessor = new ElementJsonPostProcessor(propertyManager, fileIO, logger);
     }
 
     @Test
     public void postDesiralizeAddScenarioIndexBackgroundScenarioTest() {
         Element element = new Element();
         assertThat(element.getScenarioIndex(), is(0));
-        elementPostProcessor.postDeserialize(element, null, null);
+        elementJsonPostProcessor.postDeserialize(element, null, null);
         assertThat(element.getScenarioIndex(), is(0));
-    }
-
-    @Test
-    public void postDesiralizeAddScenarioIndexTest() {
-        Element element = new Element();
-        element.setType("scenario");
-        assertThat(element.getScenarioIndex(), is(0));
-        elementPostProcessor.postDeserialize(element, null, null);
-        assertThat(element.getScenarioIndex(), is(1));
     }
 
     @Test
@@ -78,12 +69,12 @@ public class ElementPostProcessorTest {
 
         assertThat(embedding.getData(), is("123"));
 
-        elementPostProcessor.postDeserialize(element, null, null);
+        elementJsonPostProcessor.postDeserialize(element, null, null);
         assertThat(embedding.getFilename(), is("attachment001.png"));
     }
 
     @Test
     public void postSerializeTest() {
-        elementPostProcessor.postSerialize(null, null, null);
+        elementJsonPostProcessor.postSerialize(null, null, null);
     }
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/json/processors/ReportJsonPostProcessorTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/json/processors/ReportJsonPostProcessorTest.java
@@ -1,4 +1,4 @@
-package com.trivago.cluecumber.json.postprocessors;
+package com.trivago.cluecumber.json.processors;
 
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.Report;
@@ -13,12 +13,12 @@ import java.util.List;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ReportPostProcessorTest {
-    private ReportPostProcessor reportPostProcessor;
+public class ReportJsonPostProcessorTest {
+    private ReportJsonPostProcessor reportJsonPostProcessor;
 
     @Before
     public void setup() {
-        reportPostProcessor = new ReportPostProcessor();
+        reportJsonPostProcessor = new ReportJsonPostProcessor();
     }
 
     @Test
@@ -67,7 +67,7 @@ public class ReportPostProcessorTest {
 
         assertThat(report.getElements().size(), is(2));
         assertThat(report.getElements().get(1).getTags().size(), is(1));
-        reportPostProcessor.postDeserialize(report, null, null);
+        reportJsonPostProcessor.postDeserialize(report, null, null);
         assertThat(report.getElements().size(), is(1));
         Element firstElement = report.getElements().get(0);
         assertThat(firstElement.getTags().size(), is(2));
@@ -81,6 +81,6 @@ public class ReportPostProcessorTest {
 
     @Test
     public void postSerializeTest() {
-        reportPostProcessor.postSerialize(null, null, null);
+        reportJsonPostProcessor.postSerialize(null, null, null);
     }
 }


### PR DESCRIPTION
### Fixed

* Steps that are only skipped should not have a link to a scenario from the minimum/maximum time in `All Steps`
* Feature name on `Scenario Details` page was incorrectly linked

### Added

* Additional parallel run time on `All Scenarios` and `Scenario Sequence` pages
* Support of Cucumber 4.3.0's new scenario start timestamps
* Start time and date, end time and date and duration is displayed on each scenario in `All Scenarios`, `Scenario Sequence` and `Scenario Detail` pages (Cucumber >= 4.3.0)

### Changed

* `Scenario Sequence` is now not based on start time if it exists in the json file
* Minor design changes