### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Back to [Readme](README.md).
 
-## [2.2.0] - UNRELEASED
+## [2.2.0] - 2019-07-17
 
 ### Added
 
 * Hide scenarios with matching status on the `Scenario Sequence` page when disabling a status in the diagram (#175)
+* Clicking a pie chart slice toggles the according scenarios in `All Scenarios` and `Scenario Sequence` (#175)
+* Logging can be configured via the `logLevel` property (#189)
+
+### Changed
+
+* Changed internal chart generation to simplify future chart features
+* Scenario runtimes is now displayed in seconds in the `Scenario Detail` page graph (#193)
+* Renamed y axis of `All Steps` page graph to `Number of Usages` (#193)
 
 ### Fixed
 
@@ -512,6 +520,7 @@ steps with status `pending` or `undefined` (default value is `false`) (#74)
 
 Initial project version on GitHub and Maven Central.
 
+[2.2.0]: https://github.com/trivago/cluecumber-report-plugin/tree/2.2.0
 [2.1.1]: https://github.com/trivago/cluecumber-report-plugin/tree/2.1.1
 [2.1.0]: https://github.com/trivago/cluecumber-report-plugin/tree/2.1.0
 [2.0.1]: https://github.com/trivago/cluecumber-report-plugin/tree/2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Back to [Readme](README.md).
 ### Fixed
 
 * Wrong wording in `All Tags` page
+* Wrong y axis scale labels in stacked bar charts
+* Missing `All Features` navigation link
 
 ## [2.1.0] - 2019-06-25
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ This points to the root directory of the generated Cluecumber HTML report.
 
 ## Optional Configuration Parameters
 
+### Plugin Logging
+
+By default, Cluecumber logs all information including
+
+* its own name and version
+* all passed property values
+* the generated report location
+
+This can be configured by passing the `logLevel` property:
+
+```
+<logLevel>default|compact|minimal|off</logLevel>
+```
+
+* _default_ will log all the mentioned information
+* _compact_ will only log the source and target directories, plugin name and version and the generated report location
+* _minimal_ will only log the generated report location
+* _off_ will prevent any logging
+
+
 ### Add Custom Information to the Report
 
 #### Add Custom Information Using Properties

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -66,7 +66,13 @@
                     <!--<expandStepHooks>true</expandStepHooks>-->
                     <!--<expandDocStrings>true</expandDocStrings>-->
 
-                    <!-- Optional skip property for the whole report generation -->
+                    <!-- optional: Cluecumber log level -->
+                    <!--<logLevel>default</logLevel>-->
+                    <!--<logLevel>compact</logLevel>-->
+                    <logLevel>minimal</logLevel>
+                    <!--<logLevel>off</logLevel>-->
+
+                    <!-- Optionally skip the whole report generation -->
                     <!--<skip>true</skip>-->
                 </configuration>
             </plugin>

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.benjamin-bischoff</groupId>
     <artifactId>cluecumber-test-project</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -45,9 +45,9 @@
                     </customParameters>
 
                     <!-- Optional custom colors for passed, failed and skipped -->
-                    <!--<customStatusColorPassed>#017FAF</customStatusColorPassed>-->
-                    <!--<customStatusColorFailed>#C94A38</customStatusColorFailed>-->
-                    <!--<customStatusColorSkipped>#F48F00</customStatusColorSkipped>-->
+                    <customStatusColorPassed>#017FAF</customStatusColorPassed>
+                    <customStatusColorFailed>#C94A38</customStatusColorFailed>
+                    <customStatusColorSkipped>#F48F00</customStatusColorSkipped>
 
                     <!-- Optional report page title -->
                     <customPageTitle>My Report</customPageTitle>

--- a/plugin-code/pom.xml
+++ b/plugin-code/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.trivago.rta</groupId>
     <artifactId>cluecumber-report-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <url>https://github.com/trivago/cluecumber-report-plugin</url>
 
     <name>Cluecumber Maven Plugin for Cucumber Reports</name>

--- a/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/CluecumberReportPlugin.java
@@ -34,6 +34,9 @@ import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.List;
 
+import static com.trivago.cluecumber.logging.CluecumberLogger.CluecumberLogLevel.COMPACT;
+import static com.trivago.cluecumber.logging.CluecumberLogger.CluecumberLogLevel.DEFAULT;
+
 /**
  * The main plugin class.
  */
@@ -81,16 +84,18 @@ public final class CluecumberReportPlugin extends PropertyCollector {
      */
     public void execute() throws CluecumberPluginException {
         // Initialize logger to be available outside the AbstractMojo class
-        logger.setMojoLogger(getLog());
+        logger.initialize(getLog(), logLevel);
 
         if (skip) {
-            logger.info("Cluecumber report generation was skipped using the <skip> property.");
+            logger.info("Cluecumber report generation was skipped using the <skip> property.",
+                    DEFAULT);
             return;
         }
 
-        logger.logSeparator();
-        logger.info(String.format(" Cluecumber Report Maven Plugin, version %s", getClass().getPackage().getImplementationVersion()));
-        logger.logSeparator();
+        logger.logInfoSeparator(DEFAULT);
+        logger.info(String.format(" Cluecumber Report Maven Plugin, version %s", getClass().getPackage()
+                .getImplementationVersion()), DEFAULT);
+        logger.logInfoSeparator(DEFAULT, COMPACT);
 
         super.execute();
 
@@ -105,14 +110,18 @@ public final class CluecumberReportPlugin extends PropertyCollector {
                 Report[] reports = jsonPojoConverter.convertJsonToReportPojos(jsonString);
                 allScenariosPageCollection.addReports(reports);
             } catch (CluecumberPluginException e) {
-                logger.error("Could not parse JSON in file '" + jsonFilePath.toString() + "': " + e.getMessage());
+                logger.warn("Could not parse JSON in file '" + jsonFilePath.toString() + "': " + e.getMessage());
             }
         }
         elementIndexPreProcessor.addScenarioIndices(allScenariosPageCollection.getReports());
         reportGenerator.generateReport(allScenariosPageCollection);
         logger.info(
                 "=> Cluecumber Report: " + propertyManager.getGeneratedHtmlReportDirectory() + "/" +
-                        PluginSettings.SCENARIO_SUMMARY_PAGE_PATH + PluginSettings.HTML_FILE_EXTENSION);
+                        PluginSettings.SCENARIO_SUMMARY_PAGE_PATH + PluginSettings.HTML_FILE_EXTENSION,
+                DEFAULT,
+                COMPACT,
+                CluecumberLogger.CluecumberLogLevel.MINIMAL
+        );
     }
 }
 

--- a/plugin-code/src/main/java/com/trivago/cluecumber/PropertyCollector.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/PropertyCollector.java
@@ -95,6 +95,13 @@ public class PropertyCollector extends AbstractMojo {
     @Parameter(property = "reporting.customPageTitle")
     private String customPageTitle;
 
+    /**
+     * Optional log level to control what information is logged in the console.
+     * Allowed values: default, compact, minimal, off
+     */
+    @Parameter(property = "parallel.logLevel", defaultValue = "default")
+    String logLevel;
+
     @Inject
     public PropertyCollector(final PropertyManager propertyManager) {
         this.propertyManager = propertyManager;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/constants/ChartConfiguration.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/constants/ChartConfiguration.java
@@ -21,6 +21,17 @@ public class ChartConfiguration {
         this.propertyManager = propertyManager;
     }
 
+    public String getColorRgbaStringByStatus(final Status status) {
+        switch (status) {
+            case FAILED:
+                return getFailedColorRgbaString();
+            case SKIPPED:
+                return getSkippedColorRgbaString();
+            default:
+                return getPassedColorRgbaString();
+        }
+    }
+
     public String getPassedColorRgbaString() {
         if (passedColorRgbaString == null) {
             passedColorRgbaString = getRgbaColorStringFromHex(propertyManager.getCustomStatusColorPassed());

--- a/plugin-code/src/main/java/com/trivago/cluecumber/constants/ChartConfiguration.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/constants/ChartConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trivago.cluecumber.constants;
 
 import com.trivago.cluecumber.properties.PropertyManager;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessor.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/json/processors/ElementJsonPostProcessor.java
@@ -106,7 +106,7 @@ public class ElementJsonPostProcessor implements PostProcessor<Element> {
         try {
             fileIO.writeContentToFile(dataBytes, propertyManager.getGeneratedHtmlReportDirectory() + "/attachments/" + filename);
         } catch (FileCreationException e) {
-            logger.error("Could not process image " + filename + " but will continue report generation...");
+            logger.warn("Could not process image " + filename + " but will continue report generation...");
         }
         embedding.encodeData(embedding.getData());
         // Clear attachment data to reduce memory

--- a/plugin-code/src/main/java/com/trivago/cluecumber/logging/CluecumberLogger.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/logging/CluecumberLogger.java
@@ -19,25 +19,93 @@ package com.trivago.cluecumber.logging;
 import org.apache.maven.plugin.logging.Log;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
 
 @Singleton
 public class CluecumberLogger {
 
     private Log mojoLogger;
+    private CluecumberLogLevel currentLogLevel;
 
-    public void setMojoLogger(final Log mojoLogger) {
+    /**
+     * Set the mojo logger so it can be used in any class that injects a CluecumberLogger.
+     *
+     * @param mojoLogger      The current {@link Log}.
+     * @param currentLogLevel the log level that the logger should react to.
+     */
+    public void initialize(final Log mojoLogger, final String currentLogLevel) {
         this.mojoLogger = mojoLogger;
+        if (currentLogLevel == null) {
+            this.currentLogLevel = CluecumberLogLevel.DEFAULT;
+            return;
+        }
+
+        try {
+            this.currentLogLevel = CluecumberLogLevel.valueOf(currentLogLevel.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            this.currentLogLevel = CluecumberLogLevel.DEFAULT;
+            warn("Log level " + currentLogLevel + " is unknown. Cluecumber will use 'default' logging.");
+        }
     }
 
-    public void info(final CharSequence charSequence) {
-        mojoLogger.info(charSequence);
+    public void logInfoSeparator(final CluecumberLogLevel... cluecumberLogLevels) {
+        info("------------------------------------------------------------------------", cluecumberLogLevels);
     }
 
-    public void error(final CharSequence charSequence) {
-        mojoLogger.error(charSequence);
+    /**
+     * Info logging based on the provided Cluecumber log levels.
+     *
+     * @param logString           The {@link String} to be logged.
+     * @param cluecumberLogLevels The log levels ({@link CluecumberLogLevel} list) in which the message should be displayed.
+     */
+    public void info(final CharSequence logString, CluecumberLogLevel... cluecumberLogLevels) {
+        log(LogLevel.INFO, logString, cluecumberLogLevels);
     }
 
-    public void logSeparator() {
-        info("------------------------------------------------------------------------");
+    /**
+     * Warn logging. This is always displayed unless logging is off.
+     *
+     * @param logString The {@link String} to be logged.
+     */
+    public void warn(final CharSequence logString) {
+        CluecumberLogLevel[] logLevels =
+                new CluecumberLogLevel[]{CluecumberLogLevel.DEFAULT, CluecumberLogLevel.COMPACT, CluecumberLogLevel.MINIMAL};
+        log(LogLevel.WARN, logString, logLevels);
+    }
+
+    /**
+     * Logs a message based on the provided log levels.
+     *
+     * @param logString           The {@link String} to be logged.
+     * @param CluecumberLogLevels The log levels ({@link CluecumberLogger} list) in which the message should be displayed.
+     */
+    private void log(final LogLevel logLevel, final CharSequence logString, CluecumberLogLevel... CluecumberLogLevels) {
+        if (currentLogLevel == CluecumberLogLevel.OFF) {
+            return;
+        }
+
+        if (currentLogLevel != null
+                && CluecumberLogLevels != null
+                && CluecumberLogLevels.length > 0
+                && Arrays.stream(CluecumberLogLevels)
+                .noneMatch(CluecumberLogLevel -> CluecumberLogLevel == currentLogLevel)) {
+            return;
+        }
+        switch (logLevel) {
+            case INFO:
+                mojoLogger.info(logString);
+                break;
+            case WARN:
+                mojoLogger.warn(logString);
+                break;
+        }
+    }
+
+    private enum LogLevel {
+        INFO, WARN
+    }
+
+    public enum CluecumberLogLevel {
+        DEFAULT, COMPACT, MINIMAL, OFF
     }
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/properties/LinkedProperties.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/properties/LinkedProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trivago.cluecumber.properties;
 
 import java.util.Enumeration;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/properties/PropertiesFileLoader.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/properties/PropertiesFileLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trivago.cluecumber.properties;
 
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/properties/PropertyManager.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/properties/PropertyManager.java
@@ -28,6 +28,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static com.trivago.cluecumber.logging.CluecumberLogger.CluecumberLogLevel.COMPACT;
+import static com.trivago.cluecumber.logging.CluecumberLogger.CluecumberLogLevel.DEFAULT;
+
 @Singleton
 public class PropertyManager {
 
@@ -200,39 +203,39 @@ public class PropertyManager {
     }
 
     public void logProperties() {
-        logger.info("- source JSON report directory     : " + sourceJsonReportDirectory);
-        logger.info("- generated HTML report directory  : " + generatedHtmlReportDirectory);
+        logger.info("- source JSON report directory     : " + sourceJsonReportDirectory, DEFAULT, COMPACT);
+        logger.info("- generated HTML report directory  : " + generatedHtmlReportDirectory, DEFAULT, COMPACT);
 
         boolean customParametersFileExists = isSet(customParametersFile);
         if (customParametersFileExists) {
-            logger.logSeparator();
-            logger.info("- custom parameters file           : " + customParametersFile);
+            logger.logInfoSeparator(DEFAULT);
+            logger.info("- custom parameters file           : " + customParametersFile, DEFAULT);
         }
 
         if (customParameters != null && !customParameters.isEmpty()) {
             if (!customParametersFileExists) {
-                logger.logSeparator();
+                logger.logInfoSeparator();
             }
             customParameters.entrySet().stream().map(entry -> "- custom parameter                 : " +
-                    entry.getKey() + " -> " + entry.getValue()).forEach(logger::info);
+                    entry.getKey() + " -> " + entry.getValue()).forEach(logString -> logger.info(logString, DEFAULT));
         }
 
-        logger.logSeparator();
+        logger.logInfoSeparator(DEFAULT);
 
-        logger.info("- fail pending/undefined scenarios : " + failScenariosOnPendingOrUndefinedSteps);
-        logger.info("- expand before/after hooks        : " + expandBeforeAfterHooks);
-        logger.info("- expand step hooks                : " + expandStepHooks);
-        logger.info("- expand doc strings               : " + expandDocStrings);
-        logger.info("- page title                       : " + customPageTitle);
+        logger.info("- fail pending/undefined scenarios : " + failScenariosOnPendingOrUndefinedSteps, DEFAULT);
+        logger.info("- expand before/after hooks        : " + expandBeforeAfterHooks, DEFAULT);
+        logger.info("- expand step hooks                : " + expandStepHooks, DEFAULT);
+        logger.info("- expand doc strings               : " + expandDocStrings, DEFAULT);
+        logger.info("- page title                       : " + customPageTitle, DEFAULT);
 
         if (isSet(customCssFile)) {
-            logger.info("- custom CSS file                  : " + customCssFile);
+            logger.info("- custom CSS file                  : " + customCssFile, DEFAULT);
         }
 
         logger.info("- colors (passed, failed, skipped) : " +
-                customStatusColorPassed + ", " + customStatusColorFailed + ", " + customStatusColorSkipped);
+                customStatusColorPassed + ", " + customStatusColorFailed + ", " + customStatusColorSkipped, DEFAULT);
 
-        logger.logSeparator();
+        logger.logInfoSeparator(DEFAULT);
     }
 
     private boolean isSet(final String string) {

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/ChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/ChartBuilder.java
@@ -1,0 +1,92 @@
+package com.trivago.cluecumber.rendering.pages.charts;
+
+import com.trivago.cluecumber.constants.ChartConfiguration;
+import com.trivago.cluecumber.constants.Status;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChartBuilder {
+    private final ChartConfiguration.Type chartType;
+    private final ChartConfiguration chartConfiguration;
+    private List<ValueSet> valueSets;
+    private List<String> labels;
+
+    public ChartBuilder(final ChartConfiguration.Type chartType, final ChartConfiguration chartConfiguration) {
+        this.chartType = chartType;
+        this.chartConfiguration = chartConfiguration;
+        valueSets = new ArrayList<>();
+    }
+
+    public ChartBuilder useStandardLabels() {
+        List<String> labels = new ArrayList<>();
+        labels.add(Status.PASSED.getStatusString());
+        labels.add(Status.FAILED.getStatusString());
+        labels.add(Status.SKIPPED.getStatusString());
+        return setLabels(labels);
+    }
+
+    public ChartBuilder setLabels(final List<String> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    public ChartBuilder addValue(final int value, final Status status) {
+        String color;
+        switch (status) {
+            case FAILED:
+                color = chartConfiguration.getFailedColorRgbaString();
+                break;
+            case SKIPPED:
+                color = chartConfiguration.getSkippedColorRgbaString();
+                break;
+            default:
+                color = chartConfiguration.getPassedColorRgbaString();
+        }
+
+        valueSets.add(new ValueSet(value, color));
+        return this;
+    }
+
+    public Chart build() {
+
+        List<Integer> values = new ArrayList<>();
+        List<String> colors = new ArrayList<>();
+
+        for (ValueSet valueSet : valueSets) {
+            values.add(valueSet.value);
+            colors.add(valueSet.color);
+        }
+
+        Dataset dataset = new Dataset();
+        dataset.setBackgroundColor(colors);
+        dataset.setData(values);
+
+        Data data = new Data();
+        data.setLabels(labels);
+
+        List<Dataset> datasets = new ArrayList<>();
+        datasets.add(dataset);
+        data.setDatasets(datasets);
+
+        Chart chart = new Chart();
+        chart.setData(data);
+        chart.setOptions(new Options());
+        chart.setType(chartType);
+        return chart;
+    }
+
+    private class ValueSet {
+        private final int value;
+        private final String color;
+
+        ValueSet(final int value, final String color) {
+            this.value = value;
+            this.color = color;
+        }
+    }
+}

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
@@ -13,39 +13,14 @@ import java.util.List;
 public class PieChartBuilder {
     private final ChartConfiguration chartConfiguration;
     private List<ValueSet> valueSets;
-    private List<String> labels;
 
     public PieChartBuilder(final ChartConfiguration chartConfiguration) {
         this.chartConfiguration = chartConfiguration;
         valueSets = new ArrayList<>();
     }
 
-    public PieChartBuilder useStandardLabels() {
-        List<String> labels = new ArrayList<>();
-        labels.add(Status.PASSED.getStatusString());
-        labels.add(Status.FAILED.getStatusString());
-        labels.add(Status.SKIPPED.getStatusString());
-        return setLabels(labels);
-    }
-
-    public PieChartBuilder setLabels(final List<String> labels) {
-        this.labels = labels;
-        return this;
-    }
-
     public PieChartBuilder addValue(final int value, final Status status) {
-        String color;
-        switch (status) {
-            case FAILED:
-                color = chartConfiguration.getFailedColorRgbaString();
-                break;
-            case SKIPPED:
-                color = chartConfiguration.getSkippedColorRgbaString();
-                break;
-            default:
-                color = chartConfiguration.getPassedColorRgbaString();
-        }
-
+        String color = chartConfiguration.getColorRgbaStringByStatus(status);
         valueSets.add(new ValueSet(value, color));
         return this;
     }
@@ -65,6 +40,10 @@ public class PieChartBuilder {
         dataset.setData(values);
 
         Data data = new Data();
+        List<String> labels = new ArrayList<>();
+        labels.add(Status.PASSED.getStatusString());
+        labels.add(Status.FAILED.getStatusString());
+        labels.add(Status.SKIPPED.getStatusString());
         data.setLabels(labels);
 
         List<Dataset> datasets = new ArrayList<>();

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trivago.cluecumber.rendering.pages.charts;
 
 import com.trivago.cluecumber.constants.ChartConfiguration;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
@@ -52,7 +52,13 @@ public class PieChartBuilder {
 
         Chart chart = new Chart();
         chart.setData(data);
-        chart.setOptions(new Options());
+
+        final Options options = new Options();
+        List<String> events = new ArrayList<>();
+        events.add("click");
+        events.add("mousemove");
+        options.setEvents(events);
+        chart.setOptions(options);
         chart.setType(ChartConfiguration.Type.pie);
         return chart;
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/PieChartBuilder.java
@@ -1,0 +1,90 @@
+package com.trivago.cluecumber.rendering.pages.charts;
+
+import com.trivago.cluecumber.constants.ChartConfiguration;
+import com.trivago.cluecumber.constants.Status;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
+import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PieChartBuilder {
+    private final ChartConfiguration chartConfiguration;
+    private List<ValueSet> valueSets;
+    private List<String> labels;
+
+    public PieChartBuilder(final ChartConfiguration chartConfiguration) {
+        this.chartConfiguration = chartConfiguration;
+        valueSets = new ArrayList<>();
+    }
+
+    public PieChartBuilder useStandardLabels() {
+        List<String> labels = new ArrayList<>();
+        labels.add(Status.PASSED.getStatusString());
+        labels.add(Status.FAILED.getStatusString());
+        labels.add(Status.SKIPPED.getStatusString());
+        return setLabels(labels);
+    }
+
+    public PieChartBuilder setLabels(final List<String> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    public PieChartBuilder addValue(final int value, final Status status) {
+        String color;
+        switch (status) {
+            case FAILED:
+                color = chartConfiguration.getFailedColorRgbaString();
+                break;
+            case SKIPPED:
+                color = chartConfiguration.getSkippedColorRgbaString();
+                break;
+            default:
+                color = chartConfiguration.getPassedColorRgbaString();
+        }
+
+        valueSets.add(new ValueSet(value, color));
+        return this;
+    }
+
+    public Chart build() {
+
+        List<Integer> values = new ArrayList<>();
+        List<String> colors = new ArrayList<>();
+
+        for (ValueSet valueSet : valueSets) {
+            values.add(valueSet.value);
+            colors.add(valueSet.color);
+        }
+
+        Dataset dataset = new Dataset();
+        dataset.setBackgroundColor(colors);
+        dataset.setData(values);
+
+        Data data = new Data();
+        data.setLabels(labels);
+
+        List<Dataset> datasets = new ArrayList<>();
+        datasets.add(dataset);
+        data.setDatasets(datasets);
+
+        Chart chart = new Chart();
+        chart.setData(data);
+        chart.setOptions(new Options());
+        chart.setType(ChartConfiguration.Type.pie);
+        return chart;
+    }
+
+    private class ValueSet {
+        private final int value;
+        private final String color;
+
+        ValueSet(final int value, final String color) {
+            this.value = value;
+            this.color = color;
+        }
+    }
+}

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trivago.cluecumber.rendering.pages.charts;
 
 import com.trivago.cluecumber.constants.ChartConfiguration;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
@@ -10,19 +10,17 @@ import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ChartBuilder {
-    private final ChartConfiguration.Type chartType;
+public class StackedBarChartBuilder {
     private final ChartConfiguration chartConfiguration;
     private List<ValueSet> valueSets;
     private List<String> labels;
 
-    public ChartBuilder(final ChartConfiguration.Type chartType, final ChartConfiguration chartConfiguration) {
-        this.chartType = chartType;
+    public StackedBarChartBuilder(final ChartConfiguration chartConfiguration) {
         this.chartConfiguration = chartConfiguration;
         valueSets = new ArrayList<>();
     }
 
-    public ChartBuilder useStandardLabels() {
+    public StackedBarChartBuilder useStandardLabels() {
         List<String> labels = new ArrayList<>();
         labels.add(Status.PASSED.getStatusString());
         labels.add(Status.FAILED.getStatusString());
@@ -30,12 +28,12 @@ public class ChartBuilder {
         return setLabels(labels);
     }
 
-    public ChartBuilder setLabels(final List<String> labels) {
+    public StackedBarChartBuilder setLabels(final List<String> labels) {
         this.labels = labels;
         return this;
     }
 
-    public ChartBuilder addValue(final int value, final Status status) {
+    public StackedBarChartBuilder addValue(final int value, final Status status) {
         String color;
         switch (status) {
             case FAILED:
@@ -76,7 +74,7 @@ public class ChartBuilder {
         Chart chart = new Chart();
         chart.setData(data);
         chart.setOptions(new Options());
-        chart.setType(chartType);
+        chart.setType(ChartConfiguration.Type.bar);
         return chart;
     }
 

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
@@ -109,6 +109,10 @@ public class StackedBarChartBuilder {
         scales.setyAxes(yAxes);
 
         options.setScales(scales);
+        List<String> events = new ArrayList<>();
+        events.add("click");
+        events.add("mousemove");
+        options.setEvents(events);
         chart.setOptions(options);
 
         return chart;

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/StackedBarChartBuilder.java
@@ -21,6 +21,8 @@ public class StackedBarChartBuilder {
     private List<Dataset> datasets = new ArrayList<>();
     private String xAxisLabel;
     private String yAxisLabel;
+    private int yAxisStepSize = 1;
+    private boolean stacked = true;
 
     public StackedBarChartBuilder(final ChartConfiguration chartConfiguration) {
         this.chartConfiguration = chartConfiguration;
@@ -52,12 +54,29 @@ public class StackedBarChartBuilder {
         return this;
     }
 
+    public StackedBarChartBuilder setyAxisStepSize(final int yAxisStepSize) {
+        this.yAxisStepSize = yAxisStepSize;
+        return this;
+    }
+
+    public StackedBarChartBuilder setStacked(final boolean stacked) {
+        this.stacked = stacked;
+        return this;
+    }
+
     public Chart build() {
         Chart chart = new Chart();
         chart.setType(ChartConfiguration.Type.bar);
 
         Data data = new Data();
         data.setLabels(labels);
+
+        for (Dataset dataset : datasets) {
+            if (!stacked) {
+                dataset.setStack("complete");
+            }
+        }
+
         data.setDatasets(datasets);
         chart.setData(data);
 
@@ -80,7 +99,7 @@ public class StackedBarChartBuilder {
         Axis yAxis = new Axis();
         yAxis.setStacked(true);
         Ticks yTicks = new Ticks();
-        yTicks.setStepSize(1);
+        yTicks.setStepSize(yAxisStepSize);
         yAxis.setTicks(yTicks);
         ScaleLabel yScaleLabel = new ScaleLabel();
         yScaleLabel.setDisplay(true);

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/pojos/Options.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/pojos/Options.java
@@ -16,9 +16,12 @@
 
 package com.trivago.cluecumber.rendering.pages.charts.pojos;
 
+import java.util.List;
+
 public class Options {
     private Scales scales;
     private Legend legend;
+    private List<String> events;
 
     public Scales getScales() {
         return scales;
@@ -34,5 +37,13 @@ public class Options {
 
     public void setLegend(final Legend legend) {
         this.legend = legend;
+    }
+
+    public void setEvents(final List<String> events) {
+        this.events = events;
+    }
+
+    public List<String> getEvents() {
+        return events;
     }
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/pojos/Ticks.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/charts/pojos/Ticks.java
@@ -18,6 +18,7 @@ package com.trivago.cluecumber.rendering.pages.charts.pojos;
 
 public class Ticks {
     private int min;
+    private int stepSize;
     private boolean display = true;
 
     public int getMin() {
@@ -34,5 +35,13 @@ public class Ticks {
 
     public void setDisplay(final boolean display) {
         this.display = display;
+    }
+
+    public int getStepSize() {
+        return stepSize;
+    }
+
+    public void setStepSize(final int stepSize) {
+        this.stepSize = stepSize;
     }
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
@@ -19,8 +19,8 @@ package com.trivago.cluecumber.rendering.pages.renderering;
 import com.trivago.cluecumber.constants.ChartConfiguration;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
-import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
+import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
@@ -64,8 +64,8 @@ public class AllFeaturesPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllFeaturesPageCollection allFeaturesPageCollection) {
-        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
-        Chart chart = chartBuilder.build();
+        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
+        Chart chart = stackedBarChartBuilder.build();
 
         Data data = new Data();
         chart.setData(data);

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
@@ -74,7 +74,7 @@ public class AllFeaturesPageRenderer extends PageRenderer {
         Chart chart =
                 new StackedBarChartBuilder(chartConfiguration)
                         .setLabels(keys)
-                        .setxAxisLabel(allFeaturesPageCollection.getTotalNumberOfFeatures() + " Feature(s)")
+                        .setxAxisLabel(allFeaturesPageCollection.getTotalNumberOfFeatures() + " Features")
                         .setyAxisLabel("Number of Scenarios")
                         .addValues(passed, Status.PASSED)
                         .addValues(failed, Status.FAILED)

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllFeaturesPageRenderer.java
@@ -19,6 +19,7 @@ package com.trivago.cluecumber.rendering.pages.renderering;
 import com.trivago.cluecumber.constants.ChartConfiguration;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
+import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
@@ -63,7 +64,9 @@ public class AllFeaturesPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllFeaturesPageCollection allFeaturesPageCollection) {
-        Chart chart = new Chart();
+        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
+        Chart chart = chartBuilder.build();
+
         Data data = new Data();
         chart.setData(data);
 
@@ -91,14 +94,14 @@ public class AllFeaturesPageRenderer extends PageRenderer {
         Dataset failedDataset = new Dataset();
         failedDataset.setLabel(Status.FAILED.getStatusString());
         failedDataset.setData(failed);
-        List<String> failedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getFailedColorRgbaString()));
+        List<String> failedBG = new ArrayList<>(Collections.nCopies(failed.size(), chartConfiguration.getFailedColorRgbaString()));
         failedDataset.setBackgroundColor(failedBG);
         datasets.add(failedDataset);
 
         Dataset skippedDataset = new Dataset();
         skippedDataset.setLabel(Status.SKIPPED.getStatusString());
         skippedDataset.setData(skipped);
-        List<String> skippedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getSkippedColorRgbaString()));
+        List<String> skippedBG = new ArrayList<>(Collections.nCopies(skipped.size(), chartConfiguration.getSkippedColorRgbaString()));
         skippedDataset.setBackgroundColor(skippedBG);
         datasets.add(skippedDataset);
 
@@ -140,8 +143,6 @@ public class AllFeaturesPageRenderer extends PageRenderer {
 
         options.setScales(scales);
         chart.setOptions(options);
-
-        chart.setType(ChartConfiguration.Type.bar);
 
         allFeaturesPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
@@ -24,10 +24,8 @@ import com.trivago.cluecumber.json.pojo.Report;
 import com.trivago.cluecumber.json.pojo.Step;
 import com.trivago.cluecumber.json.pojo.Tag;
 import com.trivago.cluecumber.properties.PropertyManager;
+import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
 import com.trivago.cluecumber.rendering.pages.pojos.CustomParameter;
 import com.trivago.cluecumber.rendering.pages.pojos.Feature;
 import com.trivago.cluecumber.rendering.pages.pojos.pagecollections.AllScenariosPageCollection;
@@ -75,7 +73,10 @@ public class AllScenariosPageRenderer extends PageRenderer {
         AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
         allScenariosPageCollectionClone.setTagFilter(tag);
         allScenariosPageCollectionClone.getReports().forEach(report -> {
-            List<Element> elements = report.getElements().stream().filter(element -> element.getTags().contains(tag)).collect(Collectors.toList());
+            List<Element> elements = report.getElements()
+                    .stream()
+                    .filter(element -> element.getTags().contains(tag))
+                    .collect(Collectors.toList());
             report.setElements(elements);
         });
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
@@ -90,7 +91,10 @@ public class AllScenariosPageRenderer extends PageRenderer {
         AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
         allScenariosPageCollectionClone.setStepFilter(step);
         allScenariosPageCollectionClone.getReports().forEach(report -> {
-            List<Element> elements = report.getElements().stream().filter(element -> element.getSteps().contains(step)).collect(Collectors.toList());
+            List<Element> elements = report.getElements()
+                    .stream()
+                    .filter(element -> element.getSteps().contains(step))
+                    .collect(Collectors.toList());
             report.setElements(elements);
         });
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
@@ -104,7 +108,10 @@ public class AllScenariosPageRenderer extends PageRenderer {
 
         AllScenariosPageCollection allScenariosPageCollectionClone = getAllScenariosPageCollectionClone(allScenariosPageCollection);
         allScenariosPageCollectionClone.setFeatureFilter(feature);
-        Report[] reportArray = allScenariosPageCollectionClone.getReports().stream().filter(report -> report.getFeatureIndex() == feature.getIndex()).toArray(Report[]::new);
+        Report[] reportArray = allScenariosPageCollectionClone.getReports()
+                .stream()
+                .filter(report -> report.getFeatureIndex() == feature.getIndex())
+                .toArray(Report[]::new);
         allScenariosPageCollectionClone.clearReports();
         allScenariosPageCollectionClone.addReports(reportArray);
         addChartJsonToReportDetails(allScenariosPageCollectionClone);
@@ -112,35 +119,13 @@ public class AllScenariosPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllScenariosPageCollection allScenariosPageCollection) {
-        Chart chart = new Chart();
-        Data data = new Data();
+        allScenariosPageCollection.getReportDetails().setChartJson(convertChartToJson(new ChartBuilder(ChartConfiguration.Type.pie, chartConfiguration)
+                        .addValue(allScenariosPageCollection.getTotalNumberOfPassedScenarios(), Status.PASSED)
+                        .addValue(allScenariosPageCollection.getTotalNumberOfFailedScenarios(), Status.FAILED)
+                        .addValue(allScenariosPageCollection.getTotalNumberOfSkippedScenarios(), Status.SKIPPED)
+                        .useStandardLabels()
+                        .build()));
 
-        List<String> labels = new ArrayList<>();
-        labels.add(Status.PASSED.getStatusString());
-        labels.add(Status.FAILED.getStatusString());
-        labels.add(Status.SKIPPED.getStatusString());
-        data.setLabels(labels);
-
-        List<Dataset> datasets = new ArrayList<>();
-        Dataset dataset = new Dataset();
-        List<Integer> values = new ArrayList<>();
-        values.add(allScenariosPageCollection.getTotalNumberOfPassedScenarios());
-        values.add(allScenariosPageCollection.getTotalNumberOfFailedScenarios());
-        values.add(allScenariosPageCollection.getTotalNumberOfSkippedScenarios());
-        dataset.setData(values);
-        datasets.add(dataset);
-
-        List<String> backgroundColors = new ArrayList<>();
-        backgroundColors.add(chartConfiguration.getPassedColorRgbaString());
-        backgroundColors.add(chartConfiguration.getFailedColorRgbaString());
-        backgroundColors.add(chartConfiguration.getSkippedColorRgbaString());
-        dataset.setBackgroundColor(backgroundColors);
-        data.setDatasets(datasets);
-
-        chart.setData(data);
-        chart.setType(ChartConfiguration.Type.pie);
-
-        allScenariosPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }
 
     private void addCustomParametersToReportDetails(final AllScenariosPageCollection allScenariosPageCollection) {

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
@@ -124,7 +124,6 @@ public class AllScenariosPageRenderer extends PageRenderer {
                         .addValue(allScenariosPageCollection.getTotalNumberOfPassedScenarios(), Status.PASSED)
                         .addValue(allScenariosPageCollection.getTotalNumberOfFailedScenarios(), Status.FAILED)
                         .addValue(allScenariosPageCollection.getTotalNumberOfSkippedScenarios(), Status.SKIPPED)
-                        .useStandardLabels()
                         .build()));
 
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllScenariosPageRenderer.java
@@ -24,8 +24,8 @@ import com.trivago.cluecumber.json.pojo.Report;
 import com.trivago.cluecumber.json.pojo.Step;
 import com.trivago.cluecumber.json.pojo.Tag;
 import com.trivago.cluecumber.properties.PropertyManager;
-import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
+import com.trivago.cluecumber.rendering.pages.charts.PieChartBuilder;
 import com.trivago.cluecumber.rendering.pages.pojos.CustomParameter;
 import com.trivago.cluecumber.rendering.pages.pojos.Feature;
 import com.trivago.cluecumber.rendering.pages.pojos.pagecollections.AllScenariosPageCollection;
@@ -119,7 +119,8 @@ public class AllScenariosPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllScenariosPageCollection allScenariosPageCollection) {
-        allScenariosPageCollection.getReportDetails().setChartJson(convertChartToJson(new ChartBuilder(ChartConfiguration.Type.pie, chartConfiguration)
+        allScenariosPageCollection.getReportDetails()
+                .setChartJson(convertChartToJson(new PieChartBuilder(chartConfiguration)
                         .addValue(allScenariosPageCollection.getTotalNumberOfPassedScenarios(), Status.PASSED)
                         .addValue(allScenariosPageCollection.getTotalNumberOfFailedScenarios(), Status.FAILED)
                         .addValue(allScenariosPageCollection.getTotalNumberOfSkippedScenarios(), Status.SKIPPED)

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
@@ -4,8 +4,8 @@ import com.trivago.cluecumber.constants.ChartConfiguration;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Step;
-import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
+import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
@@ -46,8 +46,8 @@ public class AllStepsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllStepsPageCollection allTagsPageCollection) {
-        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
-        Chart chart = chartBuilder.build();
+        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
+        Chart chart = stackedBarChartBuilder.build();
 
         Data data = new Data();
         chart.setData(data);

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
@@ -1,8 +1,10 @@
 package com.trivago.cluecumber.rendering.pages.renderering;
 
 import com.trivago.cluecumber.constants.ChartConfiguration;
+import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Step;
+import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
@@ -44,8 +46,9 @@ public class AllStepsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllStepsPageCollection allTagsPageCollection) {
+        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
+        Chart chart = chartBuilder.build();
 
-        Chart chart = new Chart();
         Data data = new Data();
         chart.setData(data);
 
@@ -64,23 +67,23 @@ public class AllStepsPageRenderer extends PageRenderer {
         }
 
         Dataset passedDataset = new Dataset();
-        passedDataset.setLabel("passed");
+        passedDataset.setLabel(Status.PASSED.getStatusString());
         passedDataset.setData(passed);
         List<String> passedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getPassedColorRgbaString()));
         passedDataset.setBackgroundColor(passedBG);
         datasets.add(passedDataset);
 
         Dataset failedDataset = new Dataset();
-        failedDataset.setLabel("failed");
+        failedDataset.setLabel(Status.FAILED.getStatusString());
         failedDataset.setData(failed);
-        List<String> failedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getFailedColorRgbaString()));
+        List<String> failedBG = new ArrayList<>(Collections.nCopies(failed.size(), chartConfiguration.getFailedColorRgbaString()));
         failedDataset.setBackgroundColor(failedBG);
         datasets.add(failedDataset);
 
         Dataset skippedDataset = new Dataset();
-        skippedDataset.setLabel("skipped");
+        skippedDataset.setLabel(Status.SKIPPED.getStatusString());
         skippedDataset.setData(skipped);
-        List<String> skippedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getSkippedColorRgbaString()));
+        List<String> skippedBG = new ArrayList<>(Collections.nCopies(skipped.size(), chartConfiguration.getSkippedColorRgbaString()));
         skippedDataset.setBackgroundColor(skippedBG);
         datasets.add(skippedDataset);
 
@@ -122,8 +125,6 @@ public class AllStepsPageRenderer extends PageRenderer {
 
         options.setScales(scales);
         chart.setOptions(options);
-
-        chart.setType(ChartConfiguration.Type.bar);
 
         allTagsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
@@ -6,23 +6,14 @@ import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Step;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.ScaleLabel;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Scales;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Ticks;
-import com.trivago.cluecumber.rendering.pages.pojos.ResultCount;
 import com.trivago.cluecumber.rendering.pages.pojos.pagecollections.AllStepsPageCollection;
 import freemarker.template.Template;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 
 public class AllStepsPageRenderer extends PageRenderer {
 
@@ -46,85 +37,33 @@ public class AllStepsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllStepsPageCollection allTagsPageCollection) {
-        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
-        Chart chart = stackedBarChartBuilder.build();
-
-        Data data = new Data();
-        chart.setData(data);
-
-        List<Dataset> datasets = new ArrayList<>();
 
         List<Integer> passed = new ArrayList<>();
         List<Integer> failed = new ArrayList<>();
         List<Integer> skipped = new ArrayList<>();
 
-        int maxY = 0;
-        for (Map.Entry<Step, ResultCount> entry : allTagsPageCollection.getStepResultCounts().entrySet()) {
-            passed.add(entry.getValue().getPassed());
-            failed.add(entry.getValue().getFailed());
-            skipped.add(entry.getValue().getSkipped());
-            maxY = entry.getValue().getTotal();
-        }
+        allTagsPageCollection.getStepResultCounts().forEach((key, value) -> {
+            passed.add(value.getPassed());
+            failed.add(value.getFailed());
+            skipped.add(value.getSkipped());
+        });
 
-        Dataset passedDataset = new Dataset();
-        passedDataset.setLabel(Status.PASSED.getStatusString());
-        passedDataset.setData(passed);
-        List<String> passedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getPassedColorRgbaString()));
-        passedDataset.setBackgroundColor(passedBG);
-        datasets.add(passedDataset);
+        List<String> keys = allTagsPageCollection.getStepResultCounts()
+                .keySet()
+                .stream()
+                .map(Step::returnNameWithArgumentPlaceholders)
+                .collect(Collectors.toList());
 
-        Dataset failedDataset = new Dataset();
-        failedDataset.setLabel(Status.FAILED.getStatusString());
-        failedDataset.setData(failed);
-        List<String> failedBG = new ArrayList<>(Collections.nCopies(failed.size(), chartConfiguration.getFailedColorRgbaString()));
-        failedDataset.setBackgroundColor(failedBG);
-        datasets.add(failedDataset);
+        Chart chart =
+                new StackedBarChartBuilder(chartConfiguration)
+                        .setLabels(keys)
+                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfSteps() + " Step(s)")
+                        .setyAxisLabel("Number of Scenarios")
+                        .addValues(passed, Status.PASSED)
+                        .addValues(failed, Status.FAILED)
+                        .addValues(skipped, Status.SKIPPED)
+                        .build();
 
-        Dataset skippedDataset = new Dataset();
-        skippedDataset.setLabel(Status.SKIPPED.getStatusString());
-        skippedDataset.setData(skipped);
-        List<String> skippedBG = new ArrayList<>(Collections.nCopies(skipped.size(), chartConfiguration.getSkippedColorRgbaString()));
-        skippedDataset.setBackgroundColor(skippedBG);
-        datasets.add(skippedDataset);
-
-        data.setDatasets(datasets);
-
-        List<String> keys = new ArrayList<>();
-        for (Step step : allTagsPageCollection.getStepResultCounts().keySet()) {
-            keys.add(step.returnNameWithArgumentPlaceholders());
-        }
-        data.setLabels(keys);
-
-        Options options = new Options();
-        Scales scales = new Scales();
-        List<Axis> xAxes = new ArrayList<>();
-        Axis xAxis = new Axis();
-        xAxis.setStacked(true);
-        Ticks xTicks = new Ticks();
-        xTicks.setDisplay(false);
-        xAxis.setTicks(xTicks);
-        ScaleLabel xScaleLabel = new ScaleLabel();
-        xScaleLabel.setDisplay(true);
-        xScaleLabel.setLabelString(allTagsPageCollection.getTotalNumberOfSteps() + " Step(s)");
-        xAxis.setScaleLabel(xScaleLabel);
-        xAxes.add(xAxis);
-        scales.setxAxes(xAxes);
-
-        List<Axis> yAxes = new ArrayList<>();
-        Axis yAxis = new Axis();
-        yAxis.setStacked(true);
-        Ticks yTicks = new Ticks();
-        yAxis.setTicks(yTicks);
-        ScaleLabel yScaleLabel = new ScaleLabel();
-        yScaleLabel.setDisplay(true);
-        yScaleLabel.setLabelString("Number of Scenarios");
-        yAxis.setScaleLabel(yScaleLabel);
-        yAxis.setStepSize(maxY);
-        yAxes.add(yAxis);
-        scales.setyAxes(yAxes);
-
-        options.setScales(scales);
-        chart.setOptions(options);
 
         allTagsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllStepsPageRenderer.java
@@ -57,8 +57,8 @@ public class AllStepsPageRenderer extends PageRenderer {
         Chart chart =
                 new StackedBarChartBuilder(chartConfiguration)
                         .setLabels(keys)
-                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfSteps() + " Step(s)")
-                        .setyAxisLabel("Number of Scenarios")
+                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfSteps() + " Steps")
+                        .setyAxisLabel("Number of Usages")
                         .addValues(passed, Status.PASSED)
                         .addValues(failed, Status.FAILED)
                         .addValues(skipped, Status.SKIPPED)

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
@@ -75,7 +75,7 @@ public class AllTagsPageRenderer extends PageRenderer {
         Chart chart =
                 new StackedBarChartBuilder(chartConfiguration)
                         .setLabels(keys)
-                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfTags() + " Tag(s)")
+                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfTags() + " Tags")
                         .setyAxisLabel("Number of Scenarios")
                         .addValues(passed, Status.PASSED)
                         .addValues(failed, Status.FAILED)

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
@@ -17,8 +17,10 @@
 package com.trivago.cluecumber.rendering.pages.renderering;
 
 import com.trivago.cluecumber.constants.ChartConfiguration;
+import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Tag;
+import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
@@ -62,8 +64,9 @@ public class AllTagsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllTagsPageCollection allTagsPageCollection) {
+        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
+        Chart chart = chartBuilder.build();
 
-        Chart chart = new Chart();
         Data data = new Data();
         chart.setData(data);
 
@@ -82,23 +85,23 @@ public class AllTagsPageRenderer extends PageRenderer {
         }
 
         Dataset passedDataset = new Dataset();
-        passedDataset.setLabel("passed");
+        passedDataset.setLabel(Status.PASSED.getStatusString());
         passedDataset.setData(passed);
         List<String> passedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getPassedColorRgbaString()));
         passedDataset.setBackgroundColor(passedBG);
         datasets.add(passedDataset);
 
         Dataset failedDataset = new Dataset();
-        failedDataset.setLabel("failed");
+        failedDataset.setLabel(Status.FAILED.getStatusString());
         failedDataset.setData(failed);
-        List<String> failedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getFailedColorRgbaString()));
+        List<String> failedBG = new ArrayList<>(Collections.nCopies(failed.size(), chartConfiguration.getFailedColorRgbaString()));
         failedDataset.setBackgroundColor(failedBG);
         datasets.add(failedDataset);
 
         Dataset skippedDataset = new Dataset();
-        skippedDataset.setLabel("skipped");
+        skippedDataset.setLabel(Status.SKIPPED.getStatusString());
         skippedDataset.setData(skipped);
-        List<String> skippedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getSkippedColorRgbaString()));
+        List<String> skippedBG = new ArrayList<>(Collections.nCopies(skipped.size(), chartConfiguration.getSkippedColorRgbaString()));
         skippedDataset.setBackgroundColor(skippedBG);
         datasets.add(skippedDataset);
 
@@ -140,8 +143,6 @@ public class AllTagsPageRenderer extends PageRenderer {
 
         options.setScales(scales);
         chart.setOptions(options);
-
-        chart.setType(ChartConfiguration.Type.bar);
 
         allTagsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
@@ -22,14 +22,7 @@ import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Tag;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.ScaleLabel;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Scales;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Ticks;
 import com.trivago.cluecumber.rendering.pages.pojos.ResultCount;
 import com.trivago.cluecumber.rendering.pages.pojos.pagecollections.AllTagsPageCollection;
 import freemarker.template.Template;
@@ -37,7 +30,6 @@ import freemarker.template.Template;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -64,85 +56,31 @@ public class AllTagsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllTagsPageCollection allTagsPageCollection) {
-        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
-        Chart chart = stackedBarChartBuilder.build();
-
-        Data data = new Data();
-        chart.setData(data);
-
-        List<Dataset> datasets = new ArrayList<>();
 
         List<Integer> passed = new ArrayList<>();
         List<Integer> failed = new ArrayList<>();
         List<Integer> skipped = new ArrayList<>();
 
-        int maxY = 0;
         for (Map.Entry<Tag, ResultCount> entry : allTagsPageCollection.getTagResultCounts().entrySet()) {
             passed.add(entry.getValue().getPassed());
             failed.add(entry.getValue().getFailed());
             skipped.add(entry.getValue().getSkipped());
-            maxY = entry.getValue().getTotal();
         }
-
-        Dataset passedDataset = new Dataset();
-        passedDataset.setLabel(Status.PASSED.getStatusString());
-        passedDataset.setData(passed);
-        List<String> passedBG = new ArrayList<>(Collections.nCopies(passed.size(), chartConfiguration.getPassedColorRgbaString()));
-        passedDataset.setBackgroundColor(passedBG);
-        datasets.add(passedDataset);
-
-        Dataset failedDataset = new Dataset();
-        failedDataset.setLabel(Status.FAILED.getStatusString());
-        failedDataset.setData(failed);
-        List<String> failedBG = new ArrayList<>(Collections.nCopies(failed.size(), chartConfiguration.getFailedColorRgbaString()));
-        failedDataset.setBackgroundColor(failedBG);
-        datasets.add(failedDataset);
-
-        Dataset skippedDataset = new Dataset();
-        skippedDataset.setLabel(Status.SKIPPED.getStatusString());
-        skippedDataset.setData(skipped);
-        List<String> skippedBG = new ArrayList<>(Collections.nCopies(skipped.size(), chartConfiguration.getSkippedColorRgbaString()));
-        skippedDataset.setBackgroundColor(skippedBG);
-        datasets.add(skippedDataset);
-
-        data.setDatasets(datasets);
 
         List<String> keys = new ArrayList<>();
         for (Tag tag : allTagsPageCollection.getTagResultCounts().keySet()) {
             keys.add(tag.getName());
         }
-        data.setLabels(keys);
 
-        Options options = new Options();
-        Scales scales = new Scales();
-        List<Axis> xAxes = new ArrayList<>();
-        Axis xAxis = new Axis();
-        xAxis.setStacked(true);
-        Ticks xTicks = new Ticks();
-        xTicks.setDisplay(false);
-        xAxis.setTicks(xTicks);
-        ScaleLabel xScaleLabel = new ScaleLabel();
-        xScaleLabel.setDisplay(true);
-        xScaleLabel.setLabelString(allTagsPageCollection.getTotalNumberOfTags() + " Tag(s)");
-        xAxis.setScaleLabel(xScaleLabel);
-        xAxes.add(xAxis);
-        scales.setxAxes(xAxes);
-
-        List<Axis> yAxes = new ArrayList<>();
-        Axis yAxis = new Axis();
-        yAxis.setStacked(true);
-        Ticks yTicks = new Ticks();
-        yAxis.setTicks(yTicks);
-        ScaleLabel yScaleLabel = new ScaleLabel();
-        yScaleLabel.setDisplay(true);
-        yScaleLabel.setLabelString("Number of Scenarios");
-        yAxis.setScaleLabel(yScaleLabel);
-        yAxis.setStepSize(maxY);
-        yAxes.add(yAxis);
-        scales.setyAxes(yAxes);
-
-        options.setScales(scales);
-        chart.setOptions(options);
+        Chart chart =
+                new StackedBarChartBuilder(chartConfiguration)
+                        .setLabels(keys)
+                        .setxAxisLabel(allTagsPageCollection.getTotalNumberOfTags() + " Tag(s)")
+                        .setyAxisLabel("Number of Scenarios")
+                        .addValues(passed, Status.PASSED)
+                        .addValues(failed, Status.FAILED)
+                        .addValues(skipped, Status.SKIPPED)
+                        .build();
 
         allTagsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/AllTagsPageRenderer.java
@@ -20,8 +20,8 @@ import com.trivago.cluecumber.constants.ChartConfiguration;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Tag;
-import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
+import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
@@ -64,8 +64,8 @@ public class AllTagsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final AllTagsPageCollection allTagsPageCollection) {
-        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
-        Chart chart = chartBuilder.build();
+        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
+        Chart chart = stackedBarChartBuilder.build();
 
         Data data = new Data();
         chart.setData(data);

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
@@ -20,6 +20,8 @@ import com.trivago.cluecumber.constants.ChartConfiguration;
 import com.trivago.cluecumber.constants.Status;
 import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
+import com.trivago.cluecumber.json.pojo.ResultMatch;
+import com.trivago.cluecumber.json.pojo.Step;
 import com.trivago.cluecumber.properties.PropertyManager;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
@@ -31,7 +33,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 @Singleton
 public class ScenarioDetailsPageRenderer extends PageRenderer {
@@ -65,23 +66,19 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
         Element element = scenarioDetailsPageCollection.getElement();
         List<String> labels = new ArrayList<>();
         if (element.getBefore().size() > 0) {
-            IntStream.rangeClosed(1, element.getBefore().size())
-                    .mapToObj(i -> "Before " + i)
-                    .forEachOrdered(labels::add);
+            element.getBefore().stream().map(ResultMatch::getGlueMethodName).forEach(labels::add);
         }
         if (element.getSteps().size() > 0) {
-            IntStream.rangeClosed(1, element.getSteps().size()).mapToObj(i -> "Step " + i).forEachOrdered(labels::add);
+            element.getSteps().stream().map(Step::getName).forEach(labels::add);
         }
         if (element.getAfter().size() > 0) {
-            IntStream.rangeClosed(1, element.getAfter().size())
-                    .mapToObj(i -> "After " + i)
-                    .forEachOrdered(labels::add);
+            element.getAfter().stream().map(ResultMatch::getGlueMethodName).forEach(labels::add);
         }
 
         Chart chart =
                 new StackedBarChartBuilder(chartConfiguration)
-                        .setxAxisLabel("Step(s)")
-                        .setyAxisLabel("Step Runtime")
+                        .setxAxisLabel("Steps")
+                        .setyAxisLabel("Step Runtime (seconds)")
                         .setyAxisStepSize(0)
                         .setLabels(labels)
                         .setStacked(false)
@@ -97,7 +94,7 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
         List<Integer> values = new ArrayList<>();
         element.getAllResultMatches().forEach(resultMatch -> {
             if (resultMatch.getConsolidatedStatus() == status) {
-                values.add((int) resultMatch.getResult().getDurationInMilliseconds());
+                values.add((int) resultMatch.getResult().getDurationInMilliseconds() / 1000);
             } else {
                 values.add(0);
             }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
@@ -22,8 +22,8 @@ import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.ResultMatch;
 import com.trivago.cluecumber.properties.PropertyManager;
-import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
+import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
@@ -70,8 +70,8 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final ScenarioDetailsPageCollection scenarioDetailsPageCollection) {
-        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
-        Chart chart = chartBuilder.build();
+        StackedBarChartBuilder stackedBarChartBuilder = new StackedBarChartBuilder(chartConfiguration);
+        Chart chart = stackedBarChartBuilder.build();
 
         Element element = scenarioDetailsPageCollection.getElement();
         List<String> labels = new ArrayList<>();

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
@@ -23,21 +23,13 @@ import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.properties.PropertyManager;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.StackedBarChartBuilder;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Data;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Dataset;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Options;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.ScaleLabel;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Scales;
-import com.trivago.cluecumber.rendering.pages.charts.pojos.Ticks;
 import com.trivago.cluecumber.rendering.pages.pojos.pagecollections.ScenarioDetailsPageCollection;
 import freemarker.template.Template;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -72,70 +64,44 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
 
         Element element = scenarioDetailsPageCollection.getElement();
         List<String> labels = new ArrayList<>();
-        IntStream.rangeClosed(1, element.getBefore().size()).mapToObj(i -> "").forEachOrdered(labels::add);
-        IntStream.rangeClosed(1, element.getSteps().size()).mapToObj(i -> "" + i).forEachOrdered(labels::add);
+        if (element.getBefore().size() > 0) {
+            IntStream.rangeClosed(1, element.getBefore().size())
+                    .mapToObj(i -> "Before " + i)
+                    .forEachOrdered(labels::add);
+        }
+        if (element.getSteps().size() > 0) {
+            IntStream.rangeClosed(1, element.getSteps().size()).mapToObj(i -> "Step " + i).forEachOrdered(labels::add);
+        }
         if (element.getAfter().size() > 0) {
-            IntStream.rangeClosed(element.getBefore().size(), element.getAfter().size())
-                    .mapToObj(i -> "")
+            IntStream.rangeClosed(1, element.getAfter().size())
+                    .mapToObj(i -> "After " + i)
                     .forEachOrdered(labels::add);
         }
 
-        Data data = new Data();
-        data.setLabels(labels);
-
-        List<Dataset> datasets = new ArrayList<>();
-        Status.BASIC_STATES.forEach(status -> {
-            Dataset dataset = new Dataset();
-            List<Integer> dataList = new ArrayList<>();
-            element.getAllResultMatches().forEach(resultMatch -> {
-                if (resultMatch.getConsolidatedStatus() == status) {
-                    dataList.add((int) resultMatch.getResult().getDurationInMilliseconds());
-                } else {
-                    dataList.add(0);
-                }
-            });
-            dataset.setData(dataList);
-            dataset.setLabel(status.getStatusString());
-            dataset.setStack("complete");
-            String statusColorString = chartConfiguration.getColorRgbaStringByStatus(status);
-            dataset.setBackgroundColor(new ArrayList<>(Collections.nCopies(dataList.size(), statusColorString)));
-            datasets.add(dataset);
-        });
-
-        Chart chart = new StackedBarChartBuilder(chartConfiguration).build();
-
-        data.setDatasets(datasets);
-        chart.setData(data);
-
-        Options options = new Options();
-        Scales scales = new Scales();
-        List<Axis> xAxes = new ArrayList<>();
-        Axis xAxis = new Axis();
-        xAxis.setStacked(true);
-        Ticks xTicks = new Ticks();
-        xAxis.setTicks(xTicks);
-        ScaleLabel xScaleLabel = new ScaleLabel();
-        xScaleLabel.setDisplay(true);
-        xScaleLabel.setLabelString("Step(s)");
-        xAxis.setScaleLabel(xScaleLabel);
-        xAxes.add(xAxis);
-        scales.setxAxes(xAxes);
-
-        List<Axis> yAxes = new ArrayList<>();
-        Axis yAxis = new Axis();
-        yAxis.setStacked(true);
-        Ticks yTicks = new Ticks();
-        yAxis.setTicks(yTicks);
-        ScaleLabel yScaleLabel = new ScaleLabel();
-        yScaleLabel.setDisplay(true);
-        yScaleLabel.setLabelString("Step Runtime");
-        yAxis.setScaleLabel(yScaleLabel);
-        yAxes.add(yAxis);
-        scales.setyAxes(yAxes);
-
-        options.setScales(scales);
-        chart.setOptions(options);
+        Chart chart =
+                new StackedBarChartBuilder(chartConfiguration)
+                        .setxAxisLabel("Step(s)")
+                        .setyAxisLabel("Step Runtime")
+                        .setyAxisStepSize(0)
+                        .setLabels(labels)
+                        .setStacked(false)
+                        .addValues(getValuesByStatus(element, Status.PASSED), Status.PASSED)
+                        .addValues(getValuesByStatus(element, Status.FAILED), Status.FAILED)
+                        .addValues(getValuesByStatus(element, Status.SKIPPED), Status.SKIPPED)
+                        .build();
 
         scenarioDetailsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
+    }
+
+    private List<Integer> getValuesByStatus(final Element element, final Status status) {
+        List<Integer> values = new ArrayList<>();
+        element.getAllResultMatches().forEach(resultMatch -> {
+            if (resultMatch.getConsolidatedStatus() == status) {
+                values.add((int) resultMatch.getResult().getDurationInMilliseconds());
+            } else {
+                values.add(0);
+            }
+        });
+        return values;
     }
 }

--- a/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
+++ b/plugin-code/src/main/java/com/trivago/cluecumber/rendering/pages/renderering/ScenarioDetailsPageRenderer.java
@@ -22,6 +22,7 @@ import com.trivago.cluecumber.exceptions.CluecumberPluginException;
 import com.trivago.cluecumber.json.pojo.Element;
 import com.trivago.cluecumber.json.pojo.ResultMatch;
 import com.trivago.cluecumber.properties.PropertyManager;
+import com.trivago.cluecumber.rendering.pages.charts.ChartBuilder;
 import com.trivago.cluecumber.rendering.pages.charts.ChartJsonConverter;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Axis;
 import com.trivago.cluecumber.rendering.pages.charts.pojos.Chart;
@@ -69,14 +70,17 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
     }
 
     private void addChartJsonToReportDetails(final ScenarioDetailsPageCollection scenarioDetailsPageCollection) {
-        Chart chart = new Chart();
+        ChartBuilder chartBuilder = new ChartBuilder(ChartConfiguration.Type.bar, chartConfiguration);
+        Chart chart = chartBuilder.build();
 
         Element element = scenarioDetailsPageCollection.getElement();
         List<String> labels = new ArrayList<>();
-        IntStream.rangeClosed(1, element.getBefore().size()).mapToObj(i -> "Before " + i).forEachOrdered(labels::add);
-        IntStream.rangeClosed(1, element.getSteps().size()).mapToObj(i -> "Step " + i).forEachOrdered(labels::add);
+        IntStream.rangeClosed(1, element.getBefore().size()).mapToObj(i -> "").forEachOrdered(labels::add);
+        IntStream.rangeClosed(1, element.getSteps().size()).mapToObj(i -> "" + i).forEachOrdered(labels::add);
         if (element.getAfter().size() > 0) {
-            IntStream.rangeClosed(element.getBefore().size(), element.getAfter().size()).mapToObj(i -> "After " + i).forEachOrdered(labels::add);
+            IntStream.rangeClosed(element.getBefore().size(), element.getAfter().size())
+                    .mapToObj(i -> "")
+                    .forEachOrdered(labels::add);
         }
 
         Data data = new Data();
@@ -144,8 +148,6 @@ public class ScenarioDetailsPageRenderer extends PageRenderer {
 
         options.setScales(scales);
         chart.setOptions(options);
-
-        chart.setType(ChartConfiguration.Type.bar);
 
         scenarioDetailsPageCollection.getReportDetails().setChartJson(convertChartToJson(chart));
     }

--- a/plugin-code/src/main/resources/template/macros/navigation.ftl
+++ b/plugin-code/src/main/resources/template/macros/navigation.ftl
@@ -42,8 +42,8 @@ limitations under the License.
                             <#case "step_summary">
                                 <a class="nav-link ${highlightClass}" href="pages/step-summary.html">All Steps</a>
                                 <#break>
-                            <#case "feature_summary ${highlightClass}">
-                                <a class="nav-link" href="pages/feature-summary.html">All Features</a>
+                            <#case "feature_summary">
+                                <a class="nav-link ${highlightClass}" href="pages/feature-summary.html">All Features</a>
                                 <#break>
                         </#switch>
                     </li>

--- a/plugin-code/src/main/resources/template/tag-summary.ftl
+++ b/plugin-code/src/main/resources/template/tag-summary.ftl
@@ -33,7 +33,8 @@ preheadlineLink="">
         </@page.card>
         <@page.card width="3" title="Tag Summary" subtitle="" classes="">
             <ul class="list-group list-group-flush" data-cluecumber-item="tag-summary">
-                <li class="list-group-item">${totalNumberOfTags} <@common.pluralize word="Tag" unitCount=totalNumberOfTags/><br>
+                <li class="list-group-item">${totalNumberOfTags} <@common.pluralize word="Tag" unitCount=totalNumberOfTags/> in
+                    <br>
                     ${totalNumberOfScenarios} Tagged <@common.pluralize word="Scenario" unitCount=totalNumberOfScenarios/>
                 </li>
                 <li class="list-group-item">

--- a/plugin-code/src/test/java/com/trivago/cluecumber/logging/CluecumberLoggerTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/logging/CluecumberLoggerTest.java
@@ -17,7 +17,7 @@ public class CluecumberLoggerTest {
     public void setup() {
         mockedLogger = mock(Log.class);
         logger = new CluecumberLogger();
-        logger.setMojoLogger(mockedLogger);
+        logger.initialize(mockedLogger, null);
     }
 
     @Test
@@ -28,15 +28,15 @@ public class CluecumberLoggerTest {
     }
 
     @Test
-    public void errorTest() {
-        logger.error("Test");
+    public void warnTest() {
+        logger.warn("Test");
         verify(mockedLogger, times(1))
-                .error("Test");
+                .warn("Test");
     }
 
     @Test
     public void separatorTest() {
-        logger.logSeparator();
+        logger.logInfoSeparator();
         verify(mockedLogger, times(1))
                 .info("------------------------------------------------------------------------");
     }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/properties/PropertyManagerTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/properties/PropertyManagerTest.java
@@ -15,7 +15,11 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PropertyManagerTest {
     private PropertyManager propertyManager;
@@ -56,7 +60,11 @@ public class PropertyManagerTest {
     @Test
     public void logBasePropertiesTest() {
         propertyManager.logProperties();
-        verify(logger, times(8)).info(anyString());
+        verify(logger, times(2)).info(anyString(),
+                eq(CluecumberLogger.CluecumberLogLevel.DEFAULT),
+                eq(CluecumberLogger.CluecumberLogLevel.COMPACT));
+        verify(logger, times(6)).info(anyString(),
+                eq(CluecumberLogger.CluecumberLogLevel.DEFAULT));
     }
 
     @Test
@@ -188,6 +196,10 @@ public class PropertyManagerTest {
         propertyManager.setCustomCssFile("test");
 
         propertyManager.logProperties();
-        verify(logger, times(11)).info(anyString());
+        verify(logger, times(2)).info(anyString(),
+                eq(CluecumberLogger.CluecumberLogLevel.DEFAULT),
+                eq(CluecumberLogger.CluecumberLogLevel.COMPACT));
+        verify(logger, times(9)).info(anyString(),
+                eq(CluecumberLogger.CluecumberLogLevel.DEFAULT));
     }
 }

--- a/plugin-code/src/test/java/com/trivago/cluecumber/rendering/pages/charts/ChartJsonConverterTest.java
+++ b/plugin-code/src/test/java/com/trivago/cluecumber/rendering/pages/charts/ChartJsonConverterTest.java
@@ -79,6 +79,7 @@ public class ChartJsonConverterTest {
                 "        {\n" +
                 "          \"ticks\": {\n" +
                 "            \"min\": 0,\n" +
+                "            \"stepSize\": 0,\n" +
                 "            \"display\": true\n" +
                 "          },\n" +
                 "          \"stacked\": false,\n" +
@@ -93,6 +94,7 @@ public class ChartJsonConverterTest {
                 "        {\n" +
                 "          \"ticks\": {\n" +
                 "            \"min\": 0,\n" +
+                "            \"stepSize\": 0,\n" +
                 "            \"display\": true\n" +
                 "          },\n" +
                 "          \"stacked\": true,\n" +


### PR DESCRIPTION
### Added

* Hide scenarios with matching status on the `Scenario Sequence` page when disabling a status in the diagram (#175)
* Clicking a pie chart slice toggles the according scenarios in `All Scenarios` and `Scenario Sequence` (#175)
* Logging can be configured via the `logLevel` property (#189)

### Changed

* Changed internal chart generation to simplify future chart features
* Scenario runtimes is now displayed in seconds in the `Scenario Detail` page graph (#193)
* Renamed y axis of `All Steps` page graph to `Number of Usages` (#193)

### Fixed

* Wrong wording in `All Tags` page
* Wrong y axis scale labels in stacked bar charts
* Missing `All Features` navigation link
